### PR TITLE
fix(mobile): hide sidebar in note view on narrow screens

### DIFF
--- a/src/ui/CodexBrowser.tsx
+++ b/src/ui/CodexBrowser.tsx
@@ -718,7 +718,12 @@ export default function CodexBrowser({
   const titleFromPath = (rel: string) => rel.split('/').pop()?.replace(/\.md$/, '') ?? 'New note';
 
   return (
-    <div className={styles.layout}>
+    // data-view drives the mobile sidebar visibility rule in codex.module.css
+    // — on narrow screens, the sidebar gets `display: none` when view='note'
+    // so the note content owns the viewport instead of being pushed below
+    // the tree (which is the desktop layout collapsed). Hosts navigate back
+    // via their own chrome (top-bar "Notes" link, browser back, etc.).
+    <div className={styles.layout} data-view={view}>
       <aside className={styles.sidebar}>
         <div className={styles.sidebarTopBar}>
           <Link

--- a/src/ui/codex.module.css
+++ b/src/ui/codex.module.css
@@ -17,6 +17,15 @@
     border-bottom: 1px solid var(--border);
     max-height: 40vh;
   }
+
+  /* When a note is open on a narrow screen, the desktop two-column layout
+   * collapsed to single-column would push the note content below a
+   * 40vh-tall tree — the user clicks an item, sees it flash in, then the
+   * tree pushes it offscreen. Hide the tree in note view; the host's
+   * chrome (or browser back) gets the user back to the welcome/tree view. */
+  .layout[data-view='note'] .sidebar {
+    display: none;
+  }
 }
 
 .sidebar {


### PR DESCRIPTION
## Problem

On <= 768px the desktop two-column \`[sidebar | main]\` layout collapses to a single column with the sidebar stacked above the main content. In note view this meant clicking a tree item briefly showed the note, then the 40vh-tall tree pushed the content offscreen on layout settle — the user saw the tree, not the note they just clicked.

Reported by HallOfRecords first-deploy testing (chriscase/AbydosTemple#98).

## Fix

Two-line change:
1. Add \`data-view={view}\` to the outer \`.layout\` div in \`CodexBrowser.tsx\`.
2. Add a media query in \`codex.module.css\`: \`.layout[data-view='note'] .sidebar { display: none; }\` at \`max-width: 768px\`.

Welcome and graph views are unaffected — sidebar still visible there.

## Back-navigation

Hosts navigate back to the tree via their own chrome (top-bar link, browser back, or hamburger menu). Browsers handle this natively; HallOfRecords has a "Notes" link in its top bar.

## Tested

Manual: HallOfRecords on isis (\`https://temple.abydonian.com/admin/codex\`). On iPhone Safari, clicking a deeply-nested note in the tree now lands on the note content directly. Click "Notes" in the top bar to return.