### PR TITLE
fix(history): scroll panel into view + reflect open state on button

### DIFF
--- a/src/ui/CodexBrowser.tsx
+++ b/src/ui/CodexBrowser.tsx
@@ -912,6 +912,7 @@ export default function CodexBrowser({
               canEdit
               onEdit={() => setEditing(true)}
               onShowHistory={() => setHistoryOpen((v) => !v)}
+              historyOpen={historyOpen}
             />
             {historyOpen && (
               <HistoryPanel

--- a/src/ui/CodexPreview.tsx
+++ b/src/ui/CodexPreview.tsx
@@ -42,6 +42,10 @@ interface Props {
   onEdit?: () => void;
   /** Optional callback to open the per-note history side panel. */
   onShowHistory?: () => void;
+  /** Whether the history panel is currently open — toggles the History button's
+   *  pressed/active styling so the click registers visibly even if the panel
+   *  itself opens below the fold. */
+  historyOpen?: boolean;
 }
 
 const ACTIVITY_HEADING_RE = /\n## Activity[^\n]*\n(?:.*?\n)*?(?=\n## |$)/s;
@@ -162,7 +166,7 @@ function statusClass(status: string | null | undefined): string | null {
   }
 }
 
-export default function CodexPreview({ note, canEdit, onEdit, onShowHistory }: Props) {
+export default function CodexPreview({ note, canEdit, onEdit, onShowHistory, historyOpen }: Props) {
   const { Link } = useCodexNavigation();
   const md = useMemo(() => {
     const stripped = stripFrontmatter(note.content);
@@ -179,8 +183,13 @@ export default function CodexPreview({ note, canEdit, onEdit, onShowHistory }: P
         {sClass && <span className={`${styles.statusBadge} ${sClass}`}>{note.status}</span>}
         <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.5rem' }}>
           {onShowHistory && (
-            <button type="button" className={styles.btnSecondary} onClick={onShowHistory}>
-              History
+            <button
+              type="button"
+              className={`${styles.btnSecondary}${historyOpen ? ' ' + styles.btnSecondaryActive : ''}`}
+              onClick={onShowHistory}
+              aria-pressed={historyOpen ? 'true' : 'false'}
+            >
+              {historyOpen ? 'Hide history' : 'History'}
             </button>
           )}
           {canEdit && onEdit && (

--- a/src/ui/HistoryPanel.tsx
+++ b/src/ui/HistoryPanel.tsx
@@ -8,7 +8,7 @@
 // mutation. The first/most-recent entry is implicitly "current" and offers
 // no revert button.
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useCodexGraphqlRequest } from './CodexAdapters';
 import styles from './codex.module.css';
 
@@ -97,6 +97,7 @@ export default function HistoryPanel({
   onClose,
 }: Props) {
   const graphqlRequest = useCodexGraphqlRequest();
+  const panelRef = useRef<HTMLDivElement>(null);
   const [entries, setEntries] = useState<HistoryEntry[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -131,6 +132,14 @@ export default function HistoryPanel({
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // The History button lives in the note header at the top of the main
+  // column, but the panel renders below the full note body — for long
+  // notes that's offscreen, so clicking History appears to do nothing.
+  // Scroll the panel into view on mount so the user sees it open.
+  useEffect(() => {
+    panelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
 
   const active = useMemo(
     () => entries.find((e) => e.sha === activeSha) ?? null,
@@ -179,7 +188,7 @@ export default function HistoryPanel({
   }, [active, path, onReverted, refresh]);
 
   return (
-    <div className={styles.historyPanel}>
+    <div ref={panelRef} className={styles.historyPanel}>
       <div className={styles.historyHeader}>
         <strong>History</strong>
         <div style={{ display: 'flex', gap: '0.5rem' }}>

--- a/src/ui/codex.module.css
+++ b/src/ui/codex.module.css
@@ -1064,6 +1064,12 @@
   background: var(--bg-elevated, rgba(255, 255, 255, 0.06));
 }
 
+.btnSecondaryActive {
+  background: rgba(120, 200, 255, 0.18);
+  border-color: rgba(120, 200, 255, 0.55);
+  color: rgb(180, 220, 255);
+}
+
 .btnDanger {
   background: rgba(220, 80, 80, 0.15);
   color: rgb(255, 130, 130);


### PR DESCRIPTION
## Summary

The History button on a note appeared to do nothing. Diagnosis: HistoryPanel mounts correctly and the GraphQL query succeeds, but the panel renders *below* the entire note body inside .main (which has overflow-y: auto). For long notes the panel lands well below the viewport. The user clicks, nothing visible changes.

## Changes

- **Scroll into view on mount.** `panelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })` runs in a useEffect with empty deps so it fires once per open.
- **Toggle the History button's pressed state** when the panel is open: a new `historyOpen` prop on CodexPreview drives an active class on the button, swaps the label to \"Hide history\", and sets aria-pressed. This makes the click register visibly even if smooth-scroll is disabled by the browser/user.

## Test plan

- [x] `npm run type-check` clean
- [x] 187 / 187 vitest tests pass
- [ ] Smoke on temple.abydonian.com after merge + HoR ostracon git ref refresh: open a long note (_Glossary.md), click History → page scrolls down to reveal the panel, button shows pressed style + \"Hide history\" label

Reported on temple.abydonian.com (live HoR deploy).