### PR TITLE
feat(graphql): turnkey codex schema for hosts (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "exports": {
     "./server": "./src/server/index.ts",
     "./server/client": "./src/server/client.ts",
+    "./graphql": "./src/graphql/index.ts",
     "./ui": "./src/ui/index.ts",
     "./package.json": "./package.json"
   },

--- a/src/graphql/__tests__/schema.contract.test.ts
+++ b/src/graphql/__tests__/schema.contract.test.ts
@@ -1,0 +1,177 @@
+// Contract tests for the turnkey GraphQL schema export. These tests
+// don't execute resolvers (that requires a wired AuthAdapter + Prisma
+// + a real vault on disk — covered by host-side integration tests).
+// They DO verify the public surface a host depends on: field names,
+// types, argument shapes, and the ability to build a GraphQLSchema
+// from the exported field maps.
+
+import { describe, it, expect } from 'vitest';
+import {
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  printSchema,
+} from 'graphql';
+import { codexQueryFields, codexMutationFields } from '../index';
+import * as types from '../types';
+
+describe('codexQueryFields — public read surface', () => {
+  it('exposes every expected query field', () => {
+    const expected = [
+      'vaultTree',
+      'vaultNote',
+      'vaultNoteSummary',
+      'vaultGraph',
+      'vaultNoteNeighborhood',
+      'vaultSearch',
+      'vaultNoteHistory',
+      'vaultPreviewReplacement',
+      'vaultTags',
+      'myCodexPrefs',
+    ];
+    expect(Object.keys(codexQueryFields).sort()).toEqual(expected.sort());
+  });
+
+  it('every query field has a resolve function', () => {
+    for (const [name, field] of Object.entries(codexQueryFields)) {
+      expect(typeof field.resolve, `${name}.resolve`).toBe('function');
+    }
+  });
+
+  it('every query field has a type', () => {
+    for (const [name, field] of Object.entries(codexQueryFields)) {
+      expect(field.type, `${name}.type`).toBeDefined();
+    }
+  });
+});
+
+describe('codexMutationFields — public write surface', () => {
+  it('exposes every expected mutation field', () => {
+    const expected = [
+      'saveNote',
+      'createNote',
+      'renameNote',
+      'deleteNote',
+      'createFolder',
+      'renameFolder',
+      'deleteFolder',
+      'moveNote',
+      'moveFolder',
+      'revertNote',
+      'vaultApplyReplacement',
+      'renameTag',
+      'deleteTag',
+      'pinCodexNote',
+      'unpinCodexNote',
+      'bumpCodexRecent',
+    ];
+    expect(Object.keys(codexMutationFields).sort()).toEqual(expected.sort());
+  });
+
+  it('every mutation field has a resolve function', () => {
+    for (const [name, field] of Object.entries(codexMutationFields)) {
+      expect(typeof field.resolve, `${name}.resolve`).toBe('function');
+    }
+  });
+
+  it('saveNote takes path, content, baseSha, commitMessage', () => {
+    const args = codexMutationFields.saveNote.args ?? {};
+    expect(Object.keys(args).sort()).toEqual(
+      ['baseSha', 'commitMessage', 'content', 'path'].sort(),
+    );
+  });
+
+  it('createNote takes path, content, commitMessage (no baseSha)', () => {
+    const args = codexMutationFields.createNote.args ?? {};
+    expect(Object.keys(args).sort()).toEqual(
+      ['commitMessage', 'content', 'path'].sort(),
+    );
+  });
+
+  it('deleteFolder accepts a force flag', () => {
+    const args = codexMutationFields.deleteFolder.args ?? {};
+    expect(Object.keys(args)).toContain('force');
+  });
+});
+
+describe('codex types — re-exports are complete', () => {
+  it('exports every documented GraphQL type', () => {
+    const expected = [
+      'CodexNodeKindEnum',
+      'CodexTreeNodeType',
+      'CodexWikilinkType',
+      'CodexNoteSummaryType',
+      'CodexNoteType',
+      'CodexGraphNodeKindEnum',
+      'CodexGraphNodeType',
+      'CodexGraphEdgeType',
+      'CodexGraphType',
+      'CodexSearchHitMatchEnum',
+      'CodexSearchHitType',
+      'CodexSaveKindEnum',
+      'CodexSecretHitType',
+      'CodexSaveResultType',
+      'CodexRenameKindEnum',
+      'CodexRenameResultType',
+      'CodexDeleteKindEnum',
+      'CodexDeleteResultType',
+      'CodexCreateFolderKindEnum',
+      'CodexCreateFolderResultType',
+      'CodexRenameFolderKindEnum',
+      'CodexRenameFolderResultType',
+      'CodexDeleteFolderKindEnum',
+      'CodexDeleteFolderResultType',
+      'CodexHistoryEntryType',
+      'CodexRevertKindEnum',
+      'CodexRevertResultType',
+      'CodexPreviewExcerptType',
+      'CodexPreviewMatchType',
+      'CodexPreviewResultType',
+      'CodexApplyKindEnum',
+      'CodexApplyResultType',
+      'CodexTagSummaryType',
+      'CodexTagMutationKindEnum',
+      'CodexTagMutationResultType',
+      'CodexUserPrefsType',
+    ];
+    for (const name of expected) {
+      expect((types as Record<string, unknown>)[name], `types.${name}`).toBeDefined();
+    }
+  });
+});
+
+describe('host integration — can build a real GraphQLSchema from the fields', () => {
+  it('composes a working Query + Mutation schema', () => {
+    const Query = new GraphQLObjectType({
+      name: 'Query',
+      fields: { ...codexQueryFields, _ping: { type: GraphQLString } },
+    });
+    const Mutation = new GraphQLObjectType({
+      name: 'Mutation',
+      fields: codexMutationFields,
+    });
+    const schema = new GraphQLSchema({ query: Query, mutation: Mutation });
+
+    const printed = printSchema(schema);
+    // Spot-check: a few well-known field signatures appear in the SDL.
+    expect(printed).toContain('vaultNote(path: String!)');
+    expect(printed).toContain('saveNote(');
+    expect(printed).toContain('type CodexNote {');
+    expect(printed).toContain('enum CodexSaveKind');
+  });
+
+  it('produces a host-extensible schema (host can add own fields without conflict)', () => {
+    const Query = new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        ...codexQueryFields,
+        // Host's own field on the same Query type — common composition pattern.
+        hostHealthCheck: { type: GraphQLString, resolve: () => 'ok' },
+      },
+    });
+    const schema = new GraphQLSchema({ query: Query });
+    const printed = printSchema(schema);
+    expect(printed).toContain('hostHealthCheck: String');
+    expect(printed).toContain('vaultTree: CodexTreeNode!');
+  });
+});

--- a/src/graphql/context.ts
+++ b/src/graphql/context.ts
@@ -1,0 +1,31 @@
+// GraphQL context contract for Ostracon's turnkey schema.
+//
+// Hosts that consume `@chriscase/ostracon/graphql` build their Apollo /
+// graphql-yoga / mercurius context so it satisfies (or extends) this shape.
+// Codex resolvers read only these fields; host-specific fields (userId,
+// session token, RBAC role) live on the host's own extended context type
+// and are invisible to codex code.
+//
+// The required keys are:
+//   • prisma — used by the user-prefs resolvers (pin / unpin / bumpRecent /
+//     myCodexPrefs). Hosts that omit user-prefs entirely can compose only
+//     the non-prefs query / mutation fields and pass any value (cast).
+//
+// The optional keys are:
+//   • codexAuth — the AuthAdapter used by `requireCodexPermission`. Hosts
+//     register their auth impl here; unwired hosts get a clear error.
+//   • editedVia — short tag interpolated into default commit messages
+//     ("Edit <path> via <editedVia>"). Defaults to "Ostracon" when absent.
+//     Hosts customize this to "HallOfRecords v1" / "Abydonian admin" / etc.
+
+import type { PrismaClient } from '@prisma/client';
+import type { AuthAdapter } from '../server/auth-adapter';
+
+export interface CodexGraphQLContext {
+  prisma: PrismaClient;
+  codexAuth?: AuthAdapter;
+  /** Short tag interpolated into default commit messages. Hosts override
+   *  this to attribute commits to a specific frontend (e.g. "HallOfRecords
+   *  v1"). When undefined, falls back to "Ostracon". */
+  editedVia?: string;
+}

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,0 +1,16 @@
+// Ostracon — server-side GraphQL public surface.
+//
+// Re-exports every codex type + field config a host needs to compose its
+// own GraphQL schema. Hosts that consume `@chriscase/ostracon/graphql`
+// build their Query and Mutation types from `codexQueryFields` and
+// `codexMutationFields` (or pick a subset for read-only deployments).
+//
+// The context contract is `CodexGraphQLContext` — hosts extend it for
+// their own context shape (extra fields invisible to codex resolvers).
+//
+// See `chriscase/Ostracon` issue #10 for the design rationale.
+
+export * from './types';
+export * from './context';
+export * from './queries';
+export * from './mutations';

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -1,0 +1,625 @@
+// AbydosCodex GraphQL mutations — turnkey resolvers hosts can compose into
+// their own Mutation type. Every vault-touching path goes through the
+// sync coordinator (which handles the mutex + secret scan + auto-managed
+// guard + commit + debounced push). Author identity flows from the
+// AuthAdapter; commit-message phrasing pulls the host's `editedVia` tag
+// from context so "via HallOfRecords v1" / "via Abydonian admin" / etc.
+// renders correctly without host-specific code in here.
+
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLBoolean,
+  GraphQLList,
+  type GraphQLFieldConfig,
+} from 'graphql';
+import type { CodexGraphQLContext } from './context';
+import {
+  requireCodexPermission,
+  type CodexUser,
+  saveNote,
+  renameNote,
+  deleteNote,
+  createFolder,
+  renameFolder,
+  deleteFolder,
+  moveNote,
+  moveFolder,
+  revertNote,
+  applyVaultReplacement,
+  renameTag,
+  deleteTag,
+  type SaveOutcome,
+  type RenameOutcome,
+  type DeleteOutcome,
+  type CreateFolderOutcome,
+  type RenameFolderOutcome,
+  type DeleteFolderOutcome,
+  type RevertOutcome,
+  type TagMutationOutcome,
+  type ApplyOutcome,
+  bumpCodexRecent,
+  pinCodexNote,
+  unpinCodexNote,
+  vaultExists,
+} from '../server';
+import {
+  CodexSaveResultType,
+  CodexRenameResultType,
+  CodexDeleteResultType,
+  CodexCreateFolderResultType,
+  CodexRenameFolderResultType,
+  CodexRevertResultType,
+  CodexDeleteFolderResultType,
+  CodexApplyResultType,
+  CodexTagMutationResultType,
+  CodexUserPrefsType,
+} from './types';
+
+function authorFromUser(user: CodexUser) {
+  return {
+    name: user.name ?? user.email.split('@')[0],
+    email: user.email,
+  };
+}
+
+function defaultMessage(verb: string, path: string, context: CodexGraphQLContext) {
+  const via = context.editedVia ?? 'Ostracon';
+  return `${verb} ${path} via ${via}`;
+}
+
+function outcomeToPayload(outcome: SaveOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return { kind: 'OK', newSha: outcome.newSha, commitSha: outcome.commitSha };
+    case 'NOOP':
+      return { kind: 'NOOP', newSha: outcome.sha };
+    case 'CONFLICT':
+      return {
+        kind: 'CONFLICT',
+        currentContent: outcome.currentContent,
+        currentSha: outcome.currentSha,
+      };
+    case 'SECRETS':
+      return { kind: 'SECRETS', secrets: outcome.hits };
+    case 'AUTO_MANAGED':
+      return { kind: 'AUTO_MANAGED', reason: outcome.reason };
+  }
+}
+
+export const codexMutationFields: Record<
+  string,
+  GraphQLFieldConfig<unknown, CodexGraphQLContext>
+> = {
+  saveNote: {
+    type: new GraphQLNonNull(CodexSaveResultType),
+    description:
+      'Update an existing vault note. baseSha must match the SHA the caller observed; otherwise CONFLICT is returned with the current content.',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+      content: { type: new GraphQLNonNull(GraphQLString) },
+      baseSha: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        defaultMessage('Edit', args.path as string, context);
+
+      const outcome = await saveNote({
+        path: args.path as string,
+        content: args.content as string,
+        baseSha: args.baseSha as string,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return outcomeToPayload(outcome);
+    },
+  },
+
+  createNote: {
+    type: new GraphQLNonNull(CodexSaveResultType),
+    description: 'Create a new vault note at the given relative path.',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+      content: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        defaultMessage('Create', args.path as string, context);
+
+      const outcome = await saveNote({
+        path: args.path as string,
+        content: args.content as string,
+        baseSha: null,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return outcomeToPayload(outcome);
+    },
+  },
+
+  renameNote: {
+    type: new GraphQLNonNull(CodexRenameResultType),
+    description:
+      'Rename or move a vault note. Atomically rewrites every inbound wikilink and commits the rename + rewrites in one git commit.',
+    args: {
+      oldPath: { type: new GraphQLNonNull(GraphQLString) },
+      newPath: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        `Rename ${args.oldPath as string} → ${args.newPath as string} via ${context.editedVia ?? 'Ostracon'}`;
+
+      const outcome = await renameNote({
+        oldPath: args.oldPath as string,
+        newPath: args.newPath as string,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return renameOutcomeToPayload(outcome);
+    },
+  },
+
+  deleteNote: {
+    type: new GraphQLNonNull(CodexDeleteResultType),
+    description:
+      'Delete a vault note. Returns the list of paths that linked to the deleted note (now orphan links) so the UI can warn the user.',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.delete');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        defaultMessage('Delete', args.path as string, context);
+
+      const outcome = await deleteNote({
+        path: args.path as string,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return deleteOutcomeToPayload(outcome);
+    },
+  },
+
+  createFolder: {
+    type: new GraphQLNonNull(CodexCreateFolderResultType),
+    description: 'Create a new vault folder. mkdir + drop a .gitkeep so git tracks the otherwise-empty directory.',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        defaultMessage('Create folder', args.path as string, context);
+
+      const outcome = await createFolder({
+        path: args.path as string,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return createFolderOutcomeToPayload(outcome);
+    },
+  },
+
+  renameFolder: {
+    type: new GraphQLNonNull(CodexRenameFolderResultType),
+    description:
+      'Rename or move a vault folder. Recursively renames every note inside, rewrites every inbound wikilink, and commits the whole thing atomically.',
+    args: {
+      oldPath: { type: new GraphQLNonNull(GraphQLString) },
+      newPath: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        `Rename folder ${args.oldPath as string} → ${args.newPath as string} via ${context.editedVia ?? 'Ostracon'}`;
+
+      const outcome = await renameFolder({
+        oldPath: args.oldPath as string,
+        newPath: args.newPath as string,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return renameFolderOutcomeToPayload(outcome);
+    },
+  },
+
+  deleteFolder: {
+    type: new GraphQLNonNull(CodexDeleteFolderResultType),
+    description:
+      'Delete a vault folder. Refuses non-empty folders unless force=true.',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+      force: { type: GraphQLBoolean },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.delete');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        defaultMessage('Delete folder', args.path as string, context);
+
+      const outcome = await deleteFolder({
+        path: args.path as string,
+        force: (args.force as boolean | undefined) ?? false,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return deleteFolderOutcomeToPayload(outcome);
+    },
+  },
+
+  moveNote: {
+    type: new GraphQLNonNull(CodexRenameResultType),
+    description:
+      'Move a note into a different folder. Thin wrapper around renameNote that computes the destination from newParentPath + the source basename.',
+    args: {
+      oldPath: { type: new GraphQLNonNull(GraphQLString) },
+      newParentPath: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        `Move ${args.oldPath as string} → ${args.newParentPath as string} via ${context.editedVia ?? 'Ostracon'}`;
+
+      const outcome = await moveNote({
+        oldPath: args.oldPath as string,
+        newParentPath: args.newParentPath as string,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return renameOutcomeToPayload(outcome);
+    },
+  },
+
+  moveFolder: {
+    type: new GraphQLNonNull(CodexRenameFolderResultType),
+    description:
+      'Move a folder into a different parent folder. Thin wrapper around renameFolder.',
+    args: {
+      oldPath: { type: new GraphQLNonNull(GraphQLString) },
+      newParentPath: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        `Move folder ${args.oldPath as string} → ${args.newParentPath as string} via ${context.editedVia ?? 'Ostracon'}`;
+
+      const outcome = await moveFolder({
+        oldPath: args.oldPath as string,
+        newParentPath: args.newParentPath as string,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return renameFolderOutcomeToPayload(outcome);
+    },
+  },
+
+  revertNote: {
+    type: new GraphQLNonNull(CodexRevertResultType),
+    description:
+      'Restore a note to the version recorded at a specific past commit. Reads the historical content + writes it back as a new commit (NOT a `git revert`).',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+      sha: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const sha = args.sha as string;
+      const message =
+        (args.commitMessage as string | undefined)?.trim() ||
+        `Revert ${args.path as string} to ${sha.slice(0, 7)} via ${context.editedVia ?? 'Ostracon'}`;
+
+      const outcome = await revertNote({
+        path: args.path as string,
+        sha,
+        author: authorFromUser(user),
+        commitMessage: message,
+      });
+      return revertOutcomeToPayload(outcome);
+    },
+  },
+
+  vaultApplyReplacement: {
+    type: new GraphQLNonNull(CodexApplyResultType),
+    description:
+      'Apply a previously-previewed find-and-replace across the vault. Single atomic commit. Auto-managed paths skipped.',
+    args: {
+      query: { type: new GraphQLNonNull(GraphQLString) },
+      replacement: { type: new GraphQLNonNull(GraphQLString) },
+      caseSensitive: { type: GraphQLBoolean },
+      regex: { type: GraphQLBoolean },
+      wholeWord: { type: GraphQLBoolean },
+      wikilinkAware: { type: GraphQLBoolean },
+      pathScope: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const outcome = await applyVaultReplacement({
+        query: args.query as string,
+        replacement: args.replacement as string,
+        caseSensitive: (args.caseSensitive as boolean | undefined) ?? false,
+        regex: (args.regex as boolean | undefined) ?? false,
+        wholeWord: (args.wholeWord as boolean | undefined) ?? false,
+        wikilinkAware: (args.wikilinkAware as boolean | undefined) ?? false,
+        pathScope: (args.pathScope as string[] | undefined) ?? undefined,
+        author: authorFromUser(user),
+        commitMessage: (args.commitMessage as string | undefined) ?? undefined,
+      });
+      return applyOutcomeToPayload(outcome);
+    },
+  },
+
+  renameTag: {
+    type: new GraphQLNonNull(CodexTagMutationResultType),
+    description:
+      'Rename a tag across every note frontmatter. Single atomic commit. Auto-managed notes skipped.',
+    args: {
+      oldTag: { type: new GraphQLNonNull(GraphQLString) },
+      newTag: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.write');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+      const outcome = await renameTag({
+        oldTag: args.oldTag as string,
+        newTag: args.newTag as string,
+        author: authorFromUser(user),
+        commitMessage: (args.commitMessage as string | undefined) ?? undefined,
+      });
+      return tagMutationOutcomeToPayload(outcome);
+    },
+  },
+
+  deleteTag: {
+    type: new GraphQLNonNull(CodexTagMutationResultType),
+    description:
+      'Remove a tag from every note frontmatter. Single atomic commit. Auto-managed notes skipped.',
+    args: {
+      tag: { type: new GraphQLNonNull(GraphQLString) },
+      commitMessage: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.delete');
+      if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+      const outcome = await deleteTag({
+        tag: args.tag as string,
+        author: authorFromUser(user),
+        commitMessage: (args.commitMessage as string | undefined) ?? undefined,
+      });
+      return tagMutationOutcomeToPayload(outcome);
+    },
+  },
+
+  pinCodexNote: {
+    type: new GraphQLNonNull(CodexUserPrefsType),
+    description: "Add a vault path to the current user's pinned set.",
+    args: { path: { type: new GraphQLNonNull(GraphQLString) } },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.read');
+      const prefs = await pinCodexNote(context.prisma, user.id, args.path as string);
+      return {
+        recentPaths: prefs.recentPaths,
+        pinnedPaths: prefs.pinnedPaths,
+        updatedAt: prefs.updatedAt.toISOString(),
+      };
+    },
+  },
+
+  unpinCodexNote: {
+    type: new GraphQLNonNull(CodexUserPrefsType),
+    description: "Remove a vault path from the current user's pinned set.",
+    args: { path: { type: new GraphQLNonNull(GraphQLString) } },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.read');
+      const prefs = await unpinCodexNote(context.prisma, user.id, args.path as string);
+      return {
+        recentPaths: prefs.recentPaths,
+        pinnedPaths: prefs.pinnedPaths,
+        updatedAt: prefs.updatedAt.toISOString(),
+      };
+    },
+  },
+
+  bumpCodexRecent: {
+    type: new GraphQLNonNull(CodexUserPrefsType),
+    description:
+      "Move a vault path to the front of the user's recent list. Caps at 10 entries.",
+    args: { path: { type: new GraphQLNonNull(GraphQLString) } },
+    resolve: async (_parent, args, context) => {
+      const user = await requireCodexPermission(context, 'codex.read');
+      const prefs = await bumpCodexRecent(context.prisma, user.id, args.path as string);
+      return {
+        recentPaths: prefs.recentPaths,
+        pinnedPaths: prefs.pinnedPaths,
+        updatedAt: prefs.updatedAt.toISOString(),
+      };
+    },
+  },
+};
+
+function applyOutcomeToPayload(outcome: ApplyOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return {
+        kind: 'OK',
+        commitSha: outcome.commitSha,
+        filesChanged: outcome.filesChanged,
+        totalReplacements: outcome.totalReplacements,
+      };
+    case 'NOOP':
+    case 'INVALID':
+      return { kind: outcome.kind, reason: outcome.reason };
+  }
+}
+
+function tagMutationOutcomeToPayload(outcome: TagMutationOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return {
+        kind: 'OK',
+        commitSha: outcome.commitSha,
+        filesChanged: outcome.filesChanged,
+      };
+    case 'NOOP':
+    case 'INVALID':
+      return { kind: outcome.kind, reason: outcome.reason };
+  }
+}
+
+function renameOutcomeToPayload(outcome: RenameOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return {
+        kind: 'OK',
+        newPath: outcome.newPath,
+        commitSha: outcome.commitSha,
+        rewrittenFiles: outcome.rewrittenFiles,
+      };
+    case 'NOT_FOUND':
+    case 'CONFLICT':
+    case 'AUTO_MANAGED':
+    case 'INVALID':
+      return { kind: outcome.kind, reason: outcome.reason };
+  }
+}
+
+function deleteOutcomeToPayload(outcome: DeleteOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return {
+        kind: 'OK',
+        commitSha: outcome.commitSha,
+        orphanedFiles: outcome.orphanedFiles,
+      };
+    case 'NOT_FOUND':
+    case 'AUTO_MANAGED':
+    case 'INVALID':
+      return { kind: outcome.kind, reason: outcome.reason };
+  }
+}
+
+function createFolderOutcomeToPayload(outcome: CreateFolderOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return { kind: 'OK', path: outcome.path, commitSha: outcome.commitSha };
+    case 'CONFLICT':
+    case 'AUTO_MANAGED':
+    case 'INVALID':
+      return { kind: outcome.kind, reason: outcome.reason };
+  }
+}
+
+function renameFolderOutcomeToPayload(outcome: RenameFolderOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return {
+        kind: 'OK',
+        newPath: outcome.newPath,
+        commitSha: outcome.commitSha,
+        renamedNotes: outcome.renamedNotes,
+        rewrittenFiles: outcome.rewrittenFiles,
+      };
+    case 'NOT_FOUND':
+    case 'CONFLICT':
+    case 'AUTO_MANAGED':
+    case 'INVALID':
+      return { kind: outcome.kind, reason: outcome.reason };
+  }
+}
+
+function deleteFolderOutcomeToPayload(outcome: DeleteFolderOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return {
+        kind: 'OK',
+        commitSha: outcome.commitSha,
+        deletedFiles: outcome.deletedFiles,
+        orphanedFiles: outcome.orphanedFiles,
+      };
+    case 'NOT_EMPTY':
+      return {
+        kind: 'NOT_EMPTY',
+        reason: outcome.reason,
+        fileCount: outcome.fileCount,
+      };
+    case 'NOT_FOUND':
+    case 'AUTO_MANAGED':
+    case 'INVALID':
+      return { kind: outcome.kind, reason: outcome.reason };
+  }
+}
+
+function revertOutcomeToPayload(outcome: RevertOutcome) {
+  switch (outcome.kind) {
+    case 'OK':
+      return { kind: 'OK', commitSha: outcome.commitSha, newSha: outcome.newSha };
+    case 'NOT_FOUND':
+    case 'AUTO_MANAGED':
+    case 'NOOP':
+    case 'INVALID':
+      return { kind: outcome.kind, reason: outcome.reason };
+  }
+}
+
+export const {
+  saveNote: saveNoteMutation,
+  createNote: createNoteMutation,
+  renameNote: renameNoteMutation,
+  deleteNote: deleteNoteMutation,
+  createFolder: createFolderMutation,
+  renameFolder: renameFolderMutation,
+  deleteFolder: deleteFolderMutation,
+  moveNote: moveNoteMutation,
+  moveFolder: moveFolderMutation,
+  revertNote: revertNoteMutation,
+  vaultApplyReplacement: vaultApplyReplacementMutation,
+  renameTag: renameTagMutation,
+  deleteTag: deleteTagMutation,
+  pinCodexNote: pinCodexNoteMutation,
+  unpinCodexNote: unpinCodexNoteMutation,
+  bumpCodexRecent: bumpCodexRecentMutation,
+} = codexMutationFields;

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -1,0 +1,269 @@
+// AbydosCodex GraphQL queries — turnkey resolvers hosts can compose into
+// their own Query type. Every resolver goes through the AuthAdapter
+// (`requireCodexPermission`) so hosts plug their own auth without touching
+// codex code.
+
+import {
+  GraphQLString,
+  GraphQLInt,
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLList,
+  type GraphQLFieldConfig,
+} from 'graphql';
+import type { CodexGraphQLContext } from './context';
+import {
+  requireCodexPermission,
+  vaultExists,
+  readVaultFile,
+  parseNote,
+  extractWikilinks,
+  resolveWikilink,
+  getIndex,
+  getTree,
+  getNoteMeta,
+  contentSha,
+  type NoteMeta,
+  getGraph,
+  getNoteNeighborhood,
+  searchVault,
+  noteHistory,
+  computeVaultTags,
+  previewVaultReplacement,
+  getCodexUserPrefs,
+} from '../server';
+import {
+  CodexTreeNodeType,
+  CodexNoteType,
+  CodexNoteSummaryType,
+  CodexGraphType,
+  CodexSearchHitType,
+  CodexHistoryEntryType,
+  CodexPreviewResultType,
+  CodexTagSummaryType,
+  CodexUserPrefsType,
+} from './types';
+
+function summarize(meta: NoteMeta) {
+  return {
+    path: meta.path,
+    title: meta.title,
+    folder: meta.folder,
+    status: meta.status ?? null,
+    tags: meta.tags,
+    mtime: meta.mtime,
+    size: meta.size,
+    isAutoManaged: meta.isAutoManaged,
+  };
+}
+
+export const codexQueryFields: Record<
+  string,
+  GraphQLFieldConfig<unknown, CodexGraphQLContext>
+> = {
+  vaultTree: {
+    type: new GraphQLNonNull(CodexTreeNodeType),
+    description: 'Full folder/note tree of the AbydosCodex vault.',
+    resolve: async (_parent, _args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      if (!(await vaultExists())) {
+        throw new Error('Vault not found on this server. Set ABYDOS_VAULT_PATH and clone the repo.');
+      }
+      return getTree();
+    },
+  },
+
+  vaultNote: {
+    type: CodexNoteType,
+    description: 'Full content + metadata for a single note, by relative vault path.',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+    },
+    resolve: async (_parent, args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      const meta = await getNoteMeta(args.path as string);
+      if (!meta) return null;
+
+      const idx = await getIndex();
+      const content = await readVaultFile(args.path as string);
+
+      const outboundLinks = extractWikilinks(content).map((link) => ({
+        target: link.target,
+        anchor: link.anchor ?? null,
+        alias: link.alias ?? null,
+        isEmbed: link.isEmbed,
+        resolvedPath: resolveWikilink(link.target, idx.titles),
+      }));
+
+      const inboundPaths = new Set<string>();
+      for (const edge of idx.edges) {
+        if (edge.to === args.path) inboundPaths.add(edge.from);
+      }
+      const inboundLinks = [...inboundPaths]
+        .map((p) => idx.files.get(p))
+        .filter((m): m is NoteMeta => Boolean(m))
+        .map(summarize)
+        .sort((a, b) => a.path.localeCompare(b.path));
+
+      return {
+        ...summarize(meta),
+        content,
+        sha: contentSha(content),
+        outboundLinks,
+        inboundLinks,
+      };
+    },
+  },
+
+  vaultNoteSummary: {
+    type: CodexNoteSummaryType,
+    description: 'Summary metadata for a note (no content). Cheap; useful for tree/list views.',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+    },
+    resolve: async (_parent, args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      const parsed = await getNoteMeta(args.path as string);
+      void parseNote;
+      return parsed ? summarize(parsed) : null;
+    },
+  },
+
+  vaultGraph: {
+    type: new GraphQLNonNull(CodexGraphType),
+    description:
+      'Vault link graph. scope=null returns one supernode per top-level folder; scope="20 - Products" returns the per-folder note graph laid out by PageRank.',
+    args: {
+      scope: { type: GraphQLString },
+    },
+    resolve: async (_parent, args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      if (!(await vaultExists())) {
+        throw new Error('Vault not found on this server.');
+      }
+      return getGraph((args.scope as string | null | undefined) ?? null);
+    },
+  },
+
+  vaultNoteNeighborhood: {
+    type: new GraphQLNonNull(CodexGraphType),
+    description:
+      'Note-centric subgraph: BFS in the full vault edge graph (no folder boundary), depth N hops.',
+    args: {
+      notePath: { type: new GraphQLNonNull(GraphQLString) },
+      depth: { type: GraphQLInt },
+    },
+    resolve: async (_parent, args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      if (!(await vaultExists())) {
+        throw new Error('Vault not found on this server.');
+      }
+      return getNoteNeighborhood(args.notePath as string, (args.depth as number | undefined) ?? 2);
+    },
+  },
+
+  vaultSearch: {
+    type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexSearchHitType))),
+    description: 'Substring + tag search across the vault index.',
+    args: {
+      query: { type: new GraphQLNonNull(GraphQLString) },
+      limit: { type: GraphQLInt },
+    },
+    resolve: async (_parent, args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      const hits = await searchVault(args.query as string, (args.limit as number | undefined) ?? 20);
+      return hits.map((h) => ({
+        note: summarize(h.meta),
+        score: h.score,
+        matchedOn: h.matchedOn,
+      }));
+    },
+  },
+
+  vaultNoteHistory: {
+    type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexHistoryEntryType))),
+    description:
+      'Per-commit history for a vault note (uses git log --follow so renames flow). Each entry includes a path-scoped unified diff. Limit defaults to 50.',
+    args: {
+      path: { type: new GraphQLNonNull(GraphQLString) },
+      limit: { type: GraphQLInt },
+    },
+    resolve: async (_parent, args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      if (!(await vaultExists())) {
+        throw new Error('Vault not found on this server.');
+      }
+      return noteHistory(args.path as string, (args.limit as number | undefined) ?? 50);
+    },
+  },
+
+  vaultPreviewReplacement: {
+    type: new GraphQLNonNull(CodexPreviewResultType),
+    description:
+      'Non-mutating preview of a vault-wide find-and-replace. Pass `regex: true` for regex mode, `wikilinkAware: true` to interpret query/replacement as old/new vault paths.',
+    args: {
+      query: { type: new GraphQLNonNull(GraphQLString) },
+      replacement: { type: new GraphQLNonNull(GraphQLString) },
+      caseSensitive: { type: GraphQLBoolean },
+      regex: { type: GraphQLBoolean },
+      wholeWord: { type: GraphQLBoolean },
+      wikilinkAware: { type: GraphQLBoolean },
+      pathScope: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+    },
+    resolve: async (_parent, args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      if (!(await vaultExists())) {
+        throw new Error('Vault not found on this server.');
+      }
+      return previewVaultReplacement({
+        query: args.query as string,
+        replacement: args.replacement as string,
+        caseSensitive: (args.caseSensitive as boolean | undefined) ?? false,
+        regex: (args.regex as boolean | undefined) ?? false,
+        wholeWord: (args.wholeWord as boolean | undefined) ?? false,
+        wikilinkAware: (args.wikilinkAware as boolean | undefined) ?? false,
+        pathScope: (args.pathScope as string[] | undefined) ?? undefined,
+      });
+    },
+  },
+
+  vaultTags: {
+    type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexTagSummaryType))),
+    description: 'All tags across the vault, ranked by usage.',
+    resolve: async (_parent, _args, context) => {
+      await requireCodexPermission(context, 'codex.read');
+      if (!(await vaultExists())) {
+        throw new Error('Vault not found on this server.');
+      }
+      return computeVaultTags();
+    },
+  },
+
+  myCodexPrefs: {
+    type: new GraphQLNonNull(CodexUserPrefsType),
+    description:
+      'Per-user codex prefs (recent + pinned vault paths). Empty defaults for users who have never touched the codex browser.',
+    resolve: async (_parent, _args, context) => {
+      const user = await requireCodexPermission(context, 'codex.read');
+      const prefs = await getCodexUserPrefs(context.prisma, user.id);
+      return {
+        recentPaths: prefs.recentPaths,
+        pinnedPaths: prefs.pinnedPaths,
+        updatedAt: prefs.updatedAt.toISOString(),
+      };
+    },
+  },
+};
+
+export const {
+  vaultTree,
+  vaultNote,
+  vaultNoteSummary,
+  vaultGraph,
+  vaultNoteNeighborhood,
+  vaultSearch,
+  vaultNoteHistory,
+  vaultPreviewReplacement,
+  vaultTags,
+  myCodexPrefs,
+} = codexQueryFields;

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -1,0 +1,438 @@
+// AbydosCodex GraphQL types — vault tree, notes, search results, mutation
+// outcomes. These are host-agnostic — every Ostracon-backed host renders
+// the same shapes.
+
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLList,
+  GraphQLEnumType,
+  GraphQLFloat,
+  GraphQLInt,
+} from 'graphql';
+
+export const CodexNodeKindEnum = new GraphQLEnumType({
+  name: 'CodexNodeKind',
+  values: {
+    FOLDER: { value: 'FOLDER' },
+    NOTE: { value: 'NOTE' },
+  },
+});
+
+export const CodexTreeNodeType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexTreeNode',
+  fields: () => ({
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    path: { type: new GraphQLNonNull(GraphQLString) },
+    kind: { type: new GraphQLNonNull(CodexNodeKindEnum) },
+    status: { type: GraphQLString },
+    isAutoManaged: { type: GraphQLBoolean },
+    children: { type: new GraphQLList(new GraphQLNonNull(CodexTreeNodeType)) },
+  }),
+});
+
+export const CodexWikilinkType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexWikilink',
+  fields: () => ({
+    target: { type: new GraphQLNonNull(GraphQLString) },
+    anchor: { type: GraphQLString },
+    alias: { type: GraphQLString },
+    isEmbed: { type: new GraphQLNonNull(GraphQLBoolean) },
+    resolvedPath: { type: GraphQLString },
+  }),
+});
+
+export const CodexNoteSummaryType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexNoteSummary',
+  fields: () => ({
+    path: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    folder: { type: new GraphQLNonNull(GraphQLString) },
+    status: { type: GraphQLString },
+    tags: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))) },
+    mtime: { type: new GraphQLNonNull(GraphQLFloat) },
+    size: { type: new GraphQLNonNull(GraphQLInt) },
+    isAutoManaged: { type: new GraphQLNonNull(GraphQLBoolean) },
+  }),
+});
+
+export const CodexNoteType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexNote',
+  fields: () => ({
+    path: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    folder: { type: new GraphQLNonNull(GraphQLString) },
+    status: { type: GraphQLString },
+    tags: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))) },
+    mtime: { type: new GraphQLNonNull(GraphQLFloat) },
+    size: { type: new GraphQLNonNull(GraphQLInt) },
+    isAutoManaged: { type: new GraphQLNonNull(GraphQLBoolean) },
+    sha: { type: new GraphQLNonNull(GraphQLString) },
+    content: { type: new GraphQLNonNull(GraphQLString) },
+    outboundLinks: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexWikilinkType))),
+    },
+    inboundLinks: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexNoteSummaryType))),
+    },
+  }),
+});
+
+// ─── Graph + Search ─────────────────────────────────────────────
+
+export const CodexGraphNodeKindEnum = new GraphQLEnumType({
+  name: 'CodexGraphNodeKind',
+  values: {
+    SUPERNODE: { value: 'SUPERNODE' },
+    NOTE: { value: 'NOTE' },
+  },
+});
+
+export const CodexGraphNodeType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexGraphNode',
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    label: { type: new GraphQLNonNull(GraphQLString) },
+    kind: { type: new GraphQLNonNull(CodexGraphNodeKindEnum) },
+    folder: { type: new GraphQLNonNull(GraphQLString) },
+    pageRank: { type: new GraphQLNonNull(GraphQLFloat) },
+    degree: { type: new GraphQLNonNull(GraphQLInt) },
+    noteCount: { type: GraphQLInt },
+    distance: { type: GraphQLInt },
+  }),
+});
+
+export const CodexGraphEdgeType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexGraphEdge',
+  fields: () => ({
+    from: { type: new GraphQLNonNull(GraphQLString) },
+    to: { type: new GraphQLNonNull(GraphQLString) },
+    weight: { type: new GraphQLNonNull(GraphQLInt) },
+  }),
+});
+
+export const CodexGraphType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexGraph',
+  fields: () => ({
+    scope: { type: GraphQLString },
+    nodes: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexGraphNodeType))),
+    },
+    edges: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexGraphEdgeType))),
+    },
+  }),
+});
+
+export const CodexSearchHitMatchEnum = new GraphQLEnumType({
+  name: 'CodexSearchHitMatch',
+  values: {
+    title: { value: 'title' },
+    tag: { value: 'tag' },
+    path: { value: 'path' },
+    body: { value: 'body' },
+  },
+});
+
+export const CodexSearchHitType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexSearchHit',
+  fields: () => ({
+    note: { type: new GraphQLNonNull(CodexNoteSummaryType) },
+    score: { type: new GraphQLNonNull(GraphQLInt) },
+    matchedOn: { type: new GraphQLNonNull(CodexSearchHitMatchEnum) },
+    excerpt: { type: GraphQLString },
+  }),
+});
+
+// ─── Save / mutation responses ──────────────────────────────────
+
+export const CodexSaveKindEnum = new GraphQLEnumType({
+  name: 'CodexSaveKind',
+  values: {
+    OK: { value: 'OK' },
+    CONFLICT: { value: 'CONFLICT' },
+    SECRETS: { value: 'SECRETS' },
+    AUTO_MANAGED: { value: 'AUTO_MANAGED' },
+    NOOP: { value: 'NOOP' },
+  },
+});
+
+export const CodexSecretHitType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexSecretHit',
+  fields: () => ({
+    pattern: { type: new GraphQLNonNull(GraphQLString) },
+    line: { type: new GraphQLNonNull(GraphQLInt) },
+    snippet: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});
+
+export const CodexSaveResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexSaveResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexSaveKindEnum) },
+    newSha: { type: GraphQLString },
+    commitSha: { type: GraphQLString },
+    currentContent: { type: GraphQLString },
+    currentSha: { type: GraphQLString },
+    secrets: { type: new GraphQLList(new GraphQLNonNull(CodexSecretHitType)) },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── Rename / move ──────────────────────────────────────────────
+
+export const CodexRenameKindEnum = new GraphQLEnumType({
+  name: 'CodexRenameKind',
+  values: {
+    OK: { value: 'OK' },
+    NOT_FOUND: { value: 'NOT_FOUND' },
+    CONFLICT: { value: 'CONFLICT' },
+    AUTO_MANAGED: { value: 'AUTO_MANAGED' },
+    INVALID: { value: 'INVALID' },
+  },
+});
+
+export const CodexRenameResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexRenameResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexRenameKindEnum) },
+    newPath: { type: GraphQLString },
+    commitSha: { type: GraphQLString },
+    rewrittenFiles: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── Delete ─────────────────────────────────────────────────────
+
+export const CodexDeleteKindEnum = new GraphQLEnumType({
+  name: 'CodexDeleteKind',
+  values: {
+    OK: { value: 'OK' },
+    NOT_FOUND: { value: 'NOT_FOUND' },
+    AUTO_MANAGED: { value: 'AUTO_MANAGED' },
+    INVALID: { value: 'INVALID' },
+  },
+});
+
+export const CodexDeleteResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexDeleteResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexDeleteKindEnum) },
+    commitSha: { type: GraphQLString },
+    orphanedFiles: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── Create folder ──────────────────────────────────────────────
+
+export const CodexCreateFolderKindEnum = new GraphQLEnumType({
+  name: 'CodexCreateFolderKind',
+  values: {
+    OK: { value: 'OK' },
+    CONFLICT: { value: 'CONFLICT' },
+    AUTO_MANAGED: { value: 'AUTO_MANAGED' },
+    INVALID: { value: 'INVALID' },
+  },
+});
+
+export const CodexCreateFolderResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexCreateFolderResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexCreateFolderKindEnum) },
+    path: { type: GraphQLString },
+    commitSha: { type: GraphQLString },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── Rename folder ──────────────────────────────────────────────
+
+export const CodexRenameFolderKindEnum = new GraphQLEnumType({
+  name: 'CodexRenameFolderKind',
+  values: {
+    OK: { value: 'OK' },
+    NOT_FOUND: { value: 'NOT_FOUND' },
+    CONFLICT: { value: 'CONFLICT' },
+    AUTO_MANAGED: { value: 'AUTO_MANAGED' },
+    INVALID: { value: 'INVALID' },
+  },
+});
+
+export const CodexRenameFolderResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexRenameFolderResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexRenameFolderKindEnum) },
+    newPath: { type: GraphQLString },
+    commitSha: { type: GraphQLString },
+    renamedNotes: { type: GraphQLInt },
+    rewrittenFiles: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── Delete folder ──────────────────────────────────────────────
+
+export const CodexDeleteFolderKindEnum = new GraphQLEnumType({
+  name: 'CodexDeleteFolderKind',
+  values: {
+    OK: { value: 'OK' },
+    NOT_FOUND: { value: 'NOT_FOUND' },
+    NOT_EMPTY: { value: 'NOT_EMPTY' },
+    AUTO_MANAGED: { value: 'AUTO_MANAGED' },
+    INVALID: { value: 'INVALID' },
+  },
+});
+
+export const CodexDeleteFolderResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexDeleteFolderResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexDeleteFolderKindEnum) },
+    commitSha: { type: GraphQLString },
+    deletedFiles: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+    orphanedFiles: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+    fileCount: { type: GraphQLInt },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── History + revert ───────────────────────────────────────────
+
+export const CodexHistoryEntryType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexHistoryEntry',
+  fields: () => ({
+    sha: { type: new GraphQLNonNull(GraphQLString) },
+    shortSha: { type: new GraphQLNonNull(GraphQLString) },
+    authorName: { type: new GraphQLNonNull(GraphQLString) },
+    authorEmail: { type: new GraphQLNonNull(GraphQLString) },
+    date: { type: new GraphQLNonNull(GraphQLString) },
+    message: { type: new GraphQLNonNull(GraphQLString) },
+    diff: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});
+
+export const CodexRevertKindEnum = new GraphQLEnumType({
+  name: 'CodexRevertKind',
+  values: {
+    OK: { value: 'OK' },
+    NOT_FOUND: { value: 'NOT_FOUND' },
+    AUTO_MANAGED: { value: 'AUTO_MANAGED' },
+    NOOP: { value: 'NOOP' },
+    INVALID: { value: 'INVALID' },
+  },
+});
+
+export const CodexRevertResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexRevertResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexRevertKindEnum) },
+    commitSha: { type: GraphQLString },
+    newSha: { type: GraphQLString },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── Find-and-replace ───────────────────────────────────────────
+
+export const CodexPreviewExcerptType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexPreviewExcerpt',
+  fields: () => ({
+    line: { type: new GraphQLNonNull(GraphQLInt) },
+    column: { type: new GraphQLNonNull(GraphQLInt) },
+    snippet: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});
+
+export const CodexPreviewMatchType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexPreviewMatch',
+  fields: () => ({
+    path: { type: new GraphQLNonNull(GraphQLString) },
+    count: { type: new GraphQLNonNull(GraphQLInt) },
+    excerpts: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexPreviewExcerptType))),
+    },
+  }),
+});
+
+export const CodexPreviewResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexPreviewResult',
+  fields: () => ({
+    totalMatches: { type: new GraphQLNonNull(GraphQLInt) },
+    fileCount: { type: new GraphQLNonNull(GraphQLInt) },
+    matches: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexPreviewMatchType))),
+    },
+    truncated: { type: new GraphQLNonNull(GraphQLBoolean) },
+    error: { type: GraphQLString },
+  }),
+});
+
+export const CodexApplyKindEnum = new GraphQLEnumType({
+  name: 'CodexApplyKind',
+  values: {
+    OK: { value: 'OK' },
+    NOOP: { value: 'NOOP' },
+    INVALID: { value: 'INVALID' },
+  },
+});
+
+export const CodexApplyResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexApplyResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexApplyKindEnum) },
+    commitSha: { type: GraphQLString },
+    filesChanged: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+    totalReplacements: { type: GraphQLInt },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── Tag browser + tag rename/delete ────────────────────────────
+
+export const CodexTagSummaryType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexTagSummary',
+  fields: () => ({
+    tag: { type: new GraphQLNonNull(GraphQLString) },
+    count: { type: new GraphQLNonNull(GraphQLInt) },
+    notes: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))),
+    },
+  }),
+});
+
+export const CodexTagMutationKindEnum = new GraphQLEnumType({
+  name: 'CodexTagMutationKind',
+  values: {
+    OK: { value: 'OK' },
+    INVALID: { value: 'INVALID' },
+    NOOP: { value: 'NOOP' },
+  },
+});
+
+export const CodexTagMutationResultType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexTagMutationResult',
+  fields: () => ({
+    kind: { type: new GraphQLNonNull(CodexTagMutationKindEnum) },
+    commitSha: { type: GraphQLString },
+    filesChanged: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+    reason: { type: GraphQLString },
+  }),
+});
+
+// ─── User prefs ─────────────────────────────────────────────────
+
+export const CodexUserPrefsType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'CodexUserPrefs',
+  fields: () => ({
+    recentPaths: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))),
+    },
+    pinnedPaths: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))),
+    },
+    updatedAt: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});


### PR DESCRIPTION
## Summary

Move the AbydosCodex GraphQL surface — types + query / mutation resolvers — out of abydonian into Ostracon. Hosts now compose the codex API in ~20 LoC instead of copying ~1300.

New subpath: \`@chriscase/ostracon/graphql\` exports:
- All \`Codex*Type\` / \`Codex*KindEnum\` GraphQL types (verbatim move).
- \`codexQueryFields\` — Record covering 10 read fields.
- \`codexMutationFields\` — Record covering 16 write fields.
- \`CodexGraphQLContext\` — context contract that hosts extend.

Host coupling reduced to two surfaces:

1. \`context.prisma\` — used by the user-prefs resolvers. Hosts without user-prefs compose only the non-prefs fields.
2. \`context.editedVia\` — short tag interpolated into default commit messages. Defaults to \"Ostracon\". HoR will set \"HallOfRecords v1\"; abydonian to \"Abydonian admin\".

Full standardized commit-message format (with \`Note-Path:\`, \`Note-UUID:\`, \`Edited-Via:\` trailers) lands in a follow-on PR per chriscase/AbydosTemple#108.

## Migration path

- **HallOfRecords#107** will import from this subpath, drop its read-only resolver copy, and gain the full mutation surface — also fixing the silently-broken Edit button.
- **Abydonian** (follow-up PR in that repo) deletes ~1300 LoC of duplicated schema.

## Test plan

- [x] \`npm run type-check\` clean
- [x] Full vitest suite: 198 / 198 pass (11 new contract tests + 187 existing)
- [x] Schema-builder test: composes a real \`GraphQLSchema\` from the exported fields and confirms host fields can coexist on the same Query type
- [ ] Smoke-test on temple.abydonian.com after #107 merges + HoR Ostracon ref refreshes

Closes #10.