### PR TITLE
feat(uuid): stable v7 UUIDs in frontmatter (#15)

### DIFF
--- a/src/server/__tests__/sync.test.ts
+++ b/src/server/__tests__/sync.test.ts
@@ -28,11 +28,14 @@ import {
   deleteTag,
   computeVaultTags,
   syncFromRemote,
+  backfillNoteUuids,
   _resetSyncForTest,
 } from '../sync';
-import { invalidateIndex, contentSha } from '../vault-index';
+import { invalidateIndex, contentSha, getNotePathByUuid, getIndex } from '../vault-index';
 import { invalidatePageRank } from '../graph';
 import { resetGit } from '../git';
+import { parseNote } from '../frontmatter';
+import { isValidUuid } from '../uuid';
 
 const exec = promisify(execFile);
 
@@ -161,7 +164,10 @@ describe('saveNote — guard rails (no git involvement)', () => {
 
   it('returns NOOP when content is unchanged', async () => {
     const rel = '20 - Products/NoOp.md';
-    const initial = '# Same content';
+    // saveNote auto-injects a frontmatter UUID, so a true no-op needs a
+    // fixture that already carries one — otherwise the re-save becomes a
+    // real change (injecting the UUID).
+    const initial = '---\nuuid: 01970000-0000-7000-8000-000000000002\n---\n\n# Same content';
     const baseSha = await writeFixture(rel, initial);
 
     const outcome = await saveNote({
@@ -1245,5 +1251,185 @@ describe('computeVaultTags', () => {
     if (popular && niche) {
       expect(tags.indexOf(popular)).toBeLessThan(tags.indexOf(niche));
     }
+  });
+});
+
+describe('saveNote — frontmatter UUID injection', () => {
+  it('injects a v7 UUID into a new note that does not carry one', async () => {
+    const rel = '20 - Products/UuidNew.md';
+    const content = '---\ntags: [test]\n---\n\nbody';
+    const outcome = await saveNote({
+      path: rel,
+      content,
+      baseSha: null,
+      author,
+      commitMessage: 'create note',
+    });
+    expect(outcome.kind).toBe('OK');
+    const onDisk = await fs.readFile(path.join(tmpRoot, rel), 'utf8');
+    const parsed = parseNote(onDisk);
+    expect(isValidUuid(parsed.data.uuid)).toBe(true);
+  });
+
+  it('preserves an existing UUID on round-trip save', async () => {
+    const rel = '20 - Products/UuidRoundtrip.md';
+    const presetUuid = '01970000-0000-7000-8000-000000000001';
+    const content = `---\nuuid: ${presetUuid}\ntags: [test]\n---\n\nbody`;
+    // First save to write to disk.
+    await saveNote({
+      path: rel,
+      content,
+      baseSha: null,
+      author,
+      commitMessage: 'create preset',
+    });
+    const after = await fs.readFile(path.join(tmpRoot, rel), 'utf8');
+    const parsed = parseNote(after);
+    expect(parsed.data.uuid).toBe(presetUuid);
+  });
+
+  it('keeps the UUID stable when the body is edited', async () => {
+    const rel = '20 - Products/UuidStable.md';
+    // Initial save — generates a UUID.
+    await saveNote({
+      path: rel,
+      content: '---\ntags: [test]\n---\n\nbody v1',
+      baseSha: null,
+      author,
+      commitMessage: 'create',
+    });
+    const first = await fs.readFile(path.join(tmpRoot, rel), 'utf8');
+    const firstUuid = parseNote(first).data.uuid;
+    expect(isValidUuid(firstUuid)).toBe(true);
+
+    // Edit — pass back the existing content (with uuid) + a small body change.
+    const edited = first.replace('body v1', 'body v2');
+    const baseSha = contentSha(first);
+    const outcome = await saveNote({
+      path: rel,
+      content: edited,
+      baseSha,
+      author,
+      commitMessage: 'edit body',
+    });
+    expect(outcome.kind).toBe('OK');
+    const after = await fs.readFile(path.join(tmpRoot, rel), 'utf8');
+    expect(parseNote(after).data.uuid).toBe(firstUuid);
+  });
+
+  it('survives a rename — same UUID on both sides of the move', async () => {
+    const oldRel = '20 - Products/UuidRename.md';
+    const newRel = '20 - Products/UuidRenameTarget.md';
+    await saveNote({
+      path: oldRel,
+      content: '---\ntags: [test]\n---\n\nbody',
+      baseSha: null,
+      author,
+      commitMessage: 'create',
+    });
+    const beforeRename = await fs.readFile(path.join(tmpRoot, oldRel), 'utf8');
+    const originalUuid = parseNote(beforeRename).data.uuid;
+
+    const outcome = await renameNote({
+      oldPath: oldRel,
+      newPath: newRel,
+      author,
+      commitMessage: 'rename',
+    });
+    expect(outcome.kind).toBe('OK');
+
+    const afterRename = await fs.readFile(path.join(tmpRoot, newRel), 'utf8');
+    expect(parseNote(afterRename).data.uuid).toBe(originalUuid);
+  });
+
+  it('exposes uuid via NoteMeta + getNotePathByUuid resolves to current path', async () => {
+    const rel = '20 - Products/UuidLookup.md';
+    await saveNote({
+      path: rel,
+      content: '---\ntags: [test]\n---\n\nbody',
+      baseSha: null,
+      author,
+      commitMessage: 'create',
+    });
+    const raw = await fs.readFile(path.join(tmpRoot, rel), 'utf8');
+    const uuid = parseNote(raw).data.uuid;
+    expect(isValidUuid(uuid)).toBe(true);
+
+    invalidateIndex();
+    const idx = await getIndex();
+    const meta = idx.files.get(rel);
+    expect(meta?.uuid).toBe(uuid);
+    expect(idx.uuidsByPath.get(uuid as string)).toBe(rel);
+
+    const resolved = await getNotePathByUuid(uuid as string);
+    expect(resolved).toBe(rel);
+    expect(await getNotePathByUuid('00000000-0000-0000-0000-000000000000')).toBeNull();
+  });
+});
+
+describe('backfillNoteUuids', () => {
+  // Shared tmp dir is populated by prior describe blocks. Each backfill
+  // test asserts on its OWN fixtures rather than the full updatedFiles
+  // list, then runs backfill once to leave the suite in a uuid-clean
+  // state for the next test.
+
+  it('adds UUIDs to notes missing one and skips those that already have one', async () => {
+    const presetUuid = '01970000-0000-7111-8000-000000000abc';
+    await writeFixture('99 - Backfill/A.md', '---\ntags: [a]\n---\n\nbody A');
+    await writeFixture('99 - Backfill/B.md', '---\ntags: [b]\n---\n\nbody B');
+    await writeFixture(
+      '99 - Backfill/C.md',
+      `---\nuuid: ${presetUuid}\ntags: [c]\n---\n\nbody C`,
+    );
+    await exec('git', ['-C', tmpRoot, 'add', '.']);
+    await exec('git', ['-C', tmpRoot, 'commit', '-q', '-m', 'fixtures-backfill']);
+    invalidateIndex();
+
+    const outcome = await backfillNoteUuids({
+      author,
+      commitMessage: 'backfill uuids',
+    });
+    expect(outcome.kind).toBe('OK');
+    if (outcome.kind !== 'OK') return;
+    expect(outcome.updatedFiles).toContain('99 - Backfill/A.md');
+    expect(outcome.updatedFiles).toContain('99 - Backfill/B.md');
+    expect(outcome.updatedFiles).not.toContain('99 - Backfill/C.md');
+    expect(outcome.commitSha).toBeTruthy();
+
+    const a = await fs.readFile(path.join(tmpRoot, '99 - Backfill/A.md'), 'utf8');
+    const b = await fs.readFile(path.join(tmpRoot, '99 - Backfill/B.md'), 'utf8');
+    const c = await fs.readFile(path.join(tmpRoot, '99 - Backfill/C.md'), 'utf8');
+    expect(isValidUuid(parseNote(a).data.uuid)).toBe(true);
+    expect(isValidUuid(parseNote(b).data.uuid)).toBe(true);
+    expect(parseNote(c).data.uuid).toBe(presetUuid);
+  });
+
+  it('dry-run reports what would change without writing or committing', async () => {
+    const dryRel = '99 - BackfillDry/X.md';
+    await writeFixture(dryRel, '---\ntags: [x]\n---\n\nbody');
+    invalidateIndex();
+
+    const outcome = await backfillNoteUuids({
+      author,
+      dryRun: true,
+    });
+    expect(outcome.kind).toBe('OK');
+    if (outcome.kind !== 'OK') return;
+    expect(outcome.commitSha).toBeNull();
+    expect(outcome.updatedFiles).toContain(dryRel);
+
+    // The fixture file on disk must remain unchanged.
+    const x = await fs.readFile(path.join(tmpRoot, dryRel), 'utf8');
+    expect(parseNote(x).data.uuid).toBeUndefined();
+  });
+
+  it('returns NOOP after a successful run leaves no notes missing a UUID', async () => {
+    // First, make sure the vault is fully backfilled.
+    invalidateIndex();
+    await backfillNoteUuids({ author });
+    invalidateIndex();
+    // Second run must be a no-op.
+    const outcome = await backfillNoteUuids({ author });
+    expect(outcome.kind).toBe('NOOP');
   });
 });

--- a/src/server/__tests__/uuid.test.ts
+++ b/src/server/__tests__/uuid.test.ts
@@ -1,0 +1,66 @@
+// Unit tests for the UUID v7 generator. No filesystem or git involvement —
+// purely format + collision properties.
+
+import { describe, it, expect } from 'vitest';
+import { generateUuidV7, isValidUuid } from '../uuid';
+
+describe('generateUuidV7', () => {
+  it('produces canonical 36-character UUID strings', () => {
+    for (let i = 0; i < 50; i++) {
+      const u = generateUuidV7();
+      expect(u).toHaveLength(36);
+      expect(u).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    }
+  });
+
+  it('encodes version 7 in the right nibble', () => {
+    for (let i = 0; i < 50; i++) {
+      const u = generateUuidV7();
+      // Version is the first nibble of the third group.
+      expect(u[14]).toBe('7');
+    }
+  });
+
+  it('encodes variant 10xx in the right nibble', () => {
+    for (let i = 0; i < 50; i++) {
+      const u = generateUuidV7();
+      // Variant: first nibble of the fourth group must be 8, 9, a, or b.
+      expect(['8', '9', 'a', 'b']).toContain(u[19]);
+    }
+  });
+
+  it('sorts UUIDs chronologically (v7 property)', async () => {
+    const u1 = generateUuidV7();
+    // Tiny delay so the timestamp ms tick over.
+    await new Promise((r) => setTimeout(r, 2));
+    const u2 = generateUuidV7();
+    expect(u1 < u2).toBe(true);
+  });
+
+  it('does not collide across many generations in a tight loop', () => {
+    const set = new Set<string>();
+    for (let i = 0; i < 1000; i++) set.add(generateUuidV7());
+    expect(set.size).toBe(1000);
+  });
+});
+
+describe('isValidUuid', () => {
+  it('accepts well-formed v7 UUIDs', () => {
+    expect(isValidUuid(generateUuidV7())).toBe(true);
+  });
+
+  it('accepts well-formed v4 UUIDs (loose validation)', () => {
+    // v4 example
+    expect(isValidUuid('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+  });
+
+  it('rejects garbage', () => {
+    expect(isValidUuid('')).toBe(false);
+    expect(isValidUuid('not-a-uuid')).toBe(false);
+    expect(isValidUuid('123e4567-e89b-12d3-a456-42665544000g')).toBe(false); // 'g' at end
+    expect(isValidUuid(undefined)).toBe(false);
+    expect(isValidUuid(null)).toBe(false);
+    expect(isValidUuid(42)).toBe(false);
+    expect(isValidUuid({})).toBe(false);
+  });
+});

--- a/src/server/frontmatter.ts
+++ b/src/server/frontmatter.ts
@@ -12,6 +12,11 @@ export interface Frontmatter {
   created?: string;
   aliases?: string[];
   related?: string[];
+  /** Stable note identifier — injected by saveNote when missing, survives
+   *  renames/moves. Anchor for DB-backed features (comments, annotations,
+   *  embeddings, audit log). v7 UUID by default; existing values preserved
+   *  on round-trip even if they aren't v7. */
+  uuid?: string;
   // Auto-managed fields written by _scripts/nightly-journal.py
   last_mined?: string;
   [key: string]: unknown;

--- a/src/server/sync.ts
+++ b/src/server/sync.ts
@@ -41,6 +41,24 @@ import {
   getMaxUploadBytes,
   getAllowedAttachmentExts,
 } from './config';
+import { parseNote, serializeNote, type Frontmatter } from './frontmatter';
+import { generateUuidV7, isValidUuid } from './uuid';
+
+/**
+ * Ensure the content carries a frontmatter `uuid:` field. If absent, inject
+ * a fresh v7 UUID and re-serialize. Idempotent — content that already has
+ * a valid UUID round-trips unchanged.
+ *
+ * Used by saveNote and friends so every committed note carries a stable
+ * identifier from its first write. Anchors comments, annotations,
+ * embeddings, audit-log entries.
+ */
+function ensureNoteUuid(content: string): string {
+  const parsed = parseNote(content);
+  if (isValidUuid(parsed.data.uuid)) return content;
+  parsed.data.uuid = generateUuidV7();
+  return serializeNote(parsed.data, parsed.content);
+}
 
 export type SaveOutcome =
   | { kind: 'OK'; newSha: string; commitSha: string }
@@ -111,7 +129,13 @@ export async function saveNote(opts: SaveOptions): Promise<SaveOutcome> {
       return { kind: 'AUTO_MANAGED', reason: 'This file is managed by the nightly-journal automation. Edit safe sections only.' };
     }
 
-    const hits = scanContent(opts.content);
+    // Inject a stable v7 UUID into the frontmatter if missing. Idempotent
+    // on subsequent saves — content that already has a valid uuid round-
+    // trips unchanged. Done before the secret scan + no-op check so the
+    // value we scan + write + hash is the final on-disk form.
+    const finalContent = ensureNoteUuid(opts.content);
+
+    const hits = scanContent(finalContent);
     if (hits.length > 0) {
       return { kind: 'SECRETS', hits };
     }
@@ -129,7 +153,7 @@ export async function saveNote(opts: SaveOptions): Promise<SaveOutcome> {
         return { kind: 'CONFLICT', currentContent: current, currentSha };
       }
       // Unchanged content → no-op so we don't make an empty commit.
-      if (current === opts.content) {
+      if (current === finalContent) {
         return { kind: 'NOOP', sha: currentSha };
       }
     } else if (opts.baseSha !== null) {
@@ -144,9 +168,9 @@ export async function saveNote(opts: SaveOptions): Promise<SaveOutcome> {
       console.warn('[codex-sync] pre-write pull failed; proceeding with local write:', err);
     }
 
-    await writeVaultFile(opts.path, opts.content);
+    await writeVaultFile(opts.path, finalContent);
 
-    const newSha = contentSha(opts.content);
+    const newSha = contentSha(finalContent);
     const commit = await commitFiles([opts.path], opts.commitMessage, opts.author);
 
     invalidateIndex();
@@ -154,6 +178,109 @@ export async function saveNote(opts: SaveOptions): Promise<SaveOutcome> {
     schedulePush();
 
     return { kind: 'OK', newSha, commitSha: commit.sha };
+  });
+}
+
+// ─── UUID backfill ────────────────────────────────────────────────────────
+
+export type BackfillUuidsOutcome =
+  | {
+      kind: 'OK';
+      commitSha: string | null;
+      /** Vault-relative paths that received a UUID in this run. */
+      updatedFiles: string[];
+      /** Notes that already had a UUID. */
+      skipped: number;
+    }
+  | { kind: 'NOOP'; reason: string }
+  | { kind: 'INVALID'; reason: string };
+
+export interface BackfillUuidsOptions {
+  author: { name: string; email: string };
+  commitMessage?: string;
+  /** Optional dry-run — produce the list of files that WOULD be updated
+   *  without writing or committing anything. */
+  dryRun?: boolean;
+}
+
+/**
+ * One-shot backfill: walks every .md note in the vault, finds the ones
+ * without a frontmatter `uuid:` field, injects a fresh v7 UUID into
+ * each, and commits all updates in a single batch.
+ *
+ * Idempotent — re-running after a successful backfill is a NOOP.
+ * Auto-managed paths are skipped (the nightly-journal automation owns
+ * those; they can opt in to UUIDs separately if/when needed).
+ *
+ * Designed to be invoked once per existing vault. New notes saved
+ * through `saveNote` get a UUID automatically on first write.
+ */
+export async function backfillNoteUuids(
+  opts: BackfillUuidsOptions,
+): Promise<BackfillUuidsOutcome> {
+  return lock(async () => {
+    const idx = await getIndex();
+    const candidates: Array<{ rel: string; newContent: string }> = [];
+    let skipped = 0;
+
+    for (const [rel, meta] of idx.files) {
+      if (meta.isAutoManaged) continue;
+      if (meta.uuid) {
+        skipped++;
+        continue;
+      }
+      // Re-read from disk (index has body sans frontmatter; we need raw).
+      const raw = await readVaultFile(rel);
+      const parsed = parseNote(raw);
+      if (isValidUuid(parsed.data.uuid)) {
+        // Index was stale; nothing to do.
+        skipped++;
+        continue;
+      }
+      parsed.data.uuid = generateUuidV7();
+      const newContent = serializeNote(parsed.data, parsed.content);
+      candidates.push({ rel, newContent });
+    }
+
+    if (candidates.length === 0) {
+      return { kind: 'NOOP', reason: 'every note already has a uuid' };
+    }
+
+    if (opts.dryRun) {
+      return {
+        kind: 'OK',
+        commitSha: null,
+        updatedFiles: candidates.map((c) => c.rel),
+        skipped,
+      };
+    }
+
+    try {
+      await pullRebase();
+    } catch (err) {
+      console.warn('[codex-sync] pre-backfill pull failed; proceeding:', err);
+    }
+
+    for (const { rel, newContent } of candidates) {
+      await writeVaultFile(rel, newContent);
+    }
+
+    const paths = candidates.map((c) => c.rel);
+    const message =
+      opts.commitMessage?.trim() ||
+      `Backfill frontmatter UUIDs across ${paths.length} note${paths.length === 1 ? '' : 's'}`;
+    const commit = await commitFiles(paths, message, opts.author);
+
+    invalidateIndex();
+    invalidatePageRank();
+    schedulePush();
+
+    return {
+      kind: 'OK',
+      commitSha: commit.sha,
+      updatedFiles: paths,
+      skipped,
+    };
   });
 }
 
@@ -1237,12 +1364,6 @@ export async function applyVaultReplacement(
 }
 
 // ─── Tag rename / delete (chriscase/abydonian#227) ──────────────────────────
-
-import {
-  parseNote,
-  serializeNote,
-  type Frontmatter,
-} from './frontmatter';
 
 export type TagMutationOutcome =
   | { kind: 'OK'; commitSha: string; filesChanged: string[] }

--- a/src/server/uuid.ts
+++ b/src/server/uuid.ts
@@ -1,0 +1,55 @@
+// UUID v7 generator (RFC 9562 §5.7).
+//
+// v7 packs the unix-epoch millisecond timestamp in the high 48 bits so
+// UUIDs sort chronologically — useful when listing notes by creation
+// order, keeping DB index leaf pages compact, or grouping commits by
+// month without joining on mtime. The remaining 74 bits are random.
+//
+// We implement this in ~10 lines rather than pulling in the `uuid` npm
+// package — Ostracon has zero runtime deps today and this is the only
+// generator the codex needs.
+
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Generate a v7 (time-ordered) UUID as a canonical 36-character string,
+ * lowercase, dash-separated.
+ *
+ * Format: aaaaaaaa-aaaa-7xxx-yxxx-xxxxxxxxxxxx
+ *   • a... = 48-bit unix-epoch millisecond timestamp, big-endian
+ *   • 7    = version 7
+ *   • y    = variant (10xx, so y ∈ {8, 9, a, b})
+ *   • x... = random
+ */
+export function generateUuidV7(): string {
+  const buf = randomBytes(16);
+  const ts = BigInt(Date.now());
+  buf[0] = Number((ts >> 40n) & 0xffn);
+  buf[1] = Number((ts >> 32n) & 0xffn);
+  buf[2] = Number((ts >> 24n) & 0xffn);
+  buf[3] = Number((ts >> 16n) & 0xffn);
+  buf[4] = Number((ts >> 8n) & 0xffn);
+  buf[5] = Number(ts & 0xffn);
+  buf[6] = 0x70 | (buf[6] & 0x0f);
+  buf[8] = 0x80 | (buf[8] & 0x3f);
+  const hex = buf.toString('hex');
+  return (
+    hex.slice(0, 8) +
+    '-' +
+    hex.slice(8, 12) +
+    '-' +
+    hex.slice(12, 16) +
+    '-' +
+    hex.slice(16, 20) +
+    '-' +
+    hex.slice(20, 32)
+  );
+}
+
+/** Loose validation — accepts any RFC 4122-shaped UUID, not just v7. We're
+ *  trusting whoever wrote the field; this only catches obvious corruption. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidUuid(value: unknown): value is string {
+  return typeof value === 'string' && UUID_RE.test(value);
+}

--- a/src/server/vault-index.ts
+++ b/src/server/vault-index.ts
@@ -14,6 +14,7 @@ import { getVaultRoot } from './config';
 import { parseNote } from './frontmatter';
 import { extractWikilinks, resolveWikilink, type Wikilink } from './wikilinks';
 import { isAutoManagedPath } from './auto-managed';
+import { isValidUuid } from './uuid';
 
 /** SHA-256 of the raw file bytes, used as an opaque optimistic-concurrency token. */
 export function contentSha(content: string): string {
@@ -34,6 +35,11 @@ export interface NoteMeta {
   sha: string;
   /** Plain-text body content (post-frontmatter), kept in-index for body search. */
   body: string;
+  /** Stable v7 UUID from frontmatter, when present. Injected by saveNote
+   *  on first write; survives renames + moves. Anchor for DB-backed
+   *  features. Undefined for legacy notes that haven't been re-saved
+   *  yet (run `backfillNoteUuids` to populate them in bulk). */
+  uuid?: string;
 }
 
 export interface Edge {
@@ -45,6 +51,11 @@ export interface Edge {
 export interface VaultIndex {
   files: Map<string, NoteMeta>;
   titles: Map<string, string[]>;
+  /** Reverse index: frontmatter UUID → vault-relative path. Lets DB-
+   *  backed features look up the current path of a note that was
+   *  renamed since they last saw it. Only includes notes whose
+   *  frontmatter carries a `uuid:` field. */
+  uuidsByPath: Map<string, string>;
   edges: Edge[];
   builtAt: number;
 }
@@ -81,7 +92,19 @@ async function buildIndex(): Promise<VaultIndex> {
   await walk(getVaultRoot(), '', files, titles);
 
   const edges: Edge[] = [];
+  const uuidsByPath = new Map<string, string>();
   for (const [, meta] of files) {
+    if (meta.uuid) {
+      // First write wins on collision (which shouldn't happen — log it).
+      const existing = uuidsByPath.get(meta.uuid);
+      if (existing && existing !== meta.path) {
+        console.warn(
+          `[vault-index] duplicate uuid ${meta.uuid} — keeping ${existing}, ignoring ${meta.path}`,
+        );
+      } else {
+        uuidsByPath.set(meta.uuid, meta.path);
+      }
+    }
     const linkCounts = new Map<string, number>();
     for (const link of meta.outboundLinks) {
       if (link.isEmbed) continue; // attachment embeds aren't graph edges
@@ -95,7 +118,7 @@ async function buildIndex(): Promise<VaultIndex> {
     }
   }
 
-  return { files, titles, edges, builtAt: Date.now() };
+  return { files, titles, uuidsByPath, edges, builtAt: Date.now() };
 }
 
 async function walk(
@@ -140,6 +163,7 @@ async function walk(
           isAutoManaged: isAutoManagedPath(childRel),
           sha: contentSha(raw),
           body: parsed.content,
+          uuid: isValidUuid(parsed.data.uuid) ? parsed.data.uuid : undefined,
         };
         files.set(childRel, meta);
         registerTitle(titles, title, childRel);
@@ -189,6 +213,17 @@ export async function getTree(): Promise<TreeNode> {
 export async function getNoteMeta(rel: string): Promise<NoteMeta | null> {
   const idx = await getIndex();
   return idx.files.get(rel) ?? null;
+}
+
+/**
+ * Look up the current vault path of a note by its stable frontmatter UUID.
+ * Returns null when no note carries that UUID (renamed, deleted, or the
+ * UUID never existed). DB-backed features that key on UUID should use
+ * this to resolve to the current on-disk path when reading.
+ */
+export async function getNotePathByUuid(uuid: string): Promise<string | null> {
+  const idx = await getIndex();
+  return idx.uuidsByPath.get(uuid) ?? null;
 }
 
 function registerTitle(


### PR DESCRIPTION
## Summary

Every committed note now carries a frontmatter \`uuid:\` field — a v7 UUID injected by \`saveNote\` on first write, preserved on subsequent saves, preserved across renames + moves, and indexed by \`vault-index\` for constant-time lookup.

Foundation for everything DB-backed: comments / annotations anchor by uuid (not path → survive renames), search-index rows key on uuid, embedding vectors key on uuid, audit log records target_id = uuid.

## Surface

- \`src/server/uuid.ts\` — \`generateUuidV7()\`, \`isValidUuid()\` (~30 LoC, no new deps)
- \`Frontmatter.uuid?: string\` typed
- \`saveNote\` auto-injects via \`ensureNoteUuid()\`; idempotent on re-save
- \`NoteMeta.uuid?: string\`
- \`VaultIndex.uuidsByPath: Map<uuid, path>\`
- \`getNotePathByUuid(uuid): Promise<string | null>\`
- \`backfillNoteUuids({ author, commitMessage?, dryRun? })\` — one-shot bulk op for existing vaults

## Why v7 specifically

Time-ordered: chronological listing works without joining on mtime, DB indexes stay compact, B-tree leaf pages don't fragment.

## Behavior change worth noting

The existing \`saveNote\` NOOP test had a fixture with no frontmatter; with auto-injection, that's no longer a NOOP (the save adds a UUID). Updated fixture in this PR.

Real-world impact: the first save of an un-uuid'd note (whether via the UI or via backfill) creates a commit injecting the UUID. Subsequent identical saves are NOOPs as before. \"First touch leaves a fingerprint\" is the intended semantics.

## Test plan

- [x] \`npm run type-check\` clean
- [x] Full vitest: 214 / 214 (16 new + 198 prior)
- [x] uuid.test.ts: format, version/variant nibbles, chronological ordering, 1000-gen no-collision, isValidUuid acceptance + rejection
- [x] sync.test additions: auto-inject on first save, preserve existing, stable across body edits, survives rename, NoteMeta + getNotePathByUuid surface populated
- [x] backfillNoteUuids tests: adds-to-missing + skips-existing, dry-run preserves disk, NOOP-on-second-run

## Follow-up

The one-shot backfill against the live AbydosTempleCodex corpus (~1200 notes — single git commit touching ~1200 files) is a production op that should run after this lands + a HoR refresh. Will gate on user approval.

Closes #15.