### PR TITLE
feat(commits): standardized message format with git trailers

### DIFF
--- a/src/graphql/__tests__/schema.contract.test.ts
+++ b/src/graphql/__tests__/schema.contract.test.ts
@@ -74,18 +74,40 @@ describe('codexMutationFields — public write surface', () => {
     }
   });
 
-  it('saveNote takes path, content, baseSha, commitMessage', () => {
+  it('saveNote takes path, content, baseSha, userMessage, commitMessage', () => {
     const args = codexMutationFields.saveNote.args ?? {};
     expect(Object.keys(args).sort()).toEqual(
-      ['baseSha', 'commitMessage', 'content', 'path'].sort(),
+      ['baseSha', 'commitMessage', 'content', 'path', 'userMessage'].sort(),
     );
   });
 
-  it('createNote takes path, content, commitMessage (no baseSha)', () => {
+  it('createNote takes path, content, userMessage, commitMessage (no baseSha)', () => {
     const args = codexMutationFields.createNote.args ?? {};
     expect(Object.keys(args).sort()).toEqual(
-      ['commitMessage', 'content', 'path'].sort(),
+      ['commitMessage', 'content', 'path', 'userMessage'].sort(),
     );
+  });
+
+  it('every write mutation accepts userMessage', () => {
+    const writeFields = [
+      'saveNote',
+      'createNote',
+      'renameNote',
+      'deleteNote',
+      'createFolder',
+      'renameFolder',
+      'deleteFolder',
+      'moveNote',
+      'moveFolder',
+      'revertNote',
+      'vaultApplyReplacement',
+      'renameTag',
+      'deleteTag',
+    ];
+    for (const name of writeFields) {
+      const args = codexMutationFields[name].args ?? {};
+      expect(Object.keys(args), `${name}.args`).toContain('userMessage');
+    }
   });
 
   it('deleteFolder accepts a force flag', () => {

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -42,6 +42,10 @@ import {
   pinCodexNote,
   unpinCodexNote,
   vaultExists,
+  ensureNoteUuid,
+  getNoteMeta,
+  buildCodexCommitMessage,
+  type CodexCommitInput,
 } from '../server';
 import {
   CodexSaveResultType,
@@ -63,9 +67,30 @@ function authorFromUser(user: CodexUser) {
   };
 }
 
-function defaultMessage(verb: string, path: string, context: CodexGraphQLContext) {
-  const via = context.editedVia ?? 'Ostracon';
-  return `${verb} ${path} via ${via}`;
+/** Build the final commit message for a codex mutation.
+ *
+ *   1. If the caller passed a non-empty `commitMessage`, use it verbatim
+ *      (back-compat for scripts that compose their own message).
+ *   2. Otherwise, build a standardized message via
+ *      `buildCodexCommitMessage` with the verb, path, uuid (when known),
+ *      optional userMessage, and the host's `editedVia` tag. The result
+ *      always carries the trailers (`Note-Path:`, `Note-UUID:` if known,
+ *      `Edited-Via:`) so downstream tooling (audit log, search-index
+ *      sync, MCP) can extract structured fields.
+ */
+function commitMessageFor(
+  rawCommitMessage: string | undefined,
+  userMessage: string | undefined,
+  input: Omit<CodexCommitInput, 'userMessage' | 'editedVia'>,
+  context: CodexGraphQLContext,
+): string {
+  const raw = rawCommitMessage?.trim();
+  if (raw) return raw;
+  return buildCodexCommitMessage({
+    ...input,
+    userMessage: userMessage?.trim() || undefined,
+    editedVia: context.editedVia,
+  });
 }
 
 function outcomeToPayload(outcome: SaveOutcome) {
@@ -94,20 +119,28 @@ export const codexMutationFields: Record<
   saveNote: {
     type: new GraphQLNonNull(CodexSaveResultType),
     description:
-      'Update an existing vault note. baseSha must match the SHA the caller observed; otherwise CONFLICT is returned with the current content.',
+      'Update an existing vault note. baseSha must match the SHA the caller observed; otherwise CONFLICT is returned with the current content. Set `userMessage` for the standardized commit format with trailers; set `commitMessage` to override the whole message verbatim.',
     args: {
       path: { type: new GraphQLNonNull(GraphQLString) },
       content: { type: new GraphQLNonNull(GraphQLString) },
       baseSha: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        defaultMessage('Edit', args.path as string, context);
+      // Compute the post-injection UUID up front so the commit message
+      // carries the Note-UUID trailer. saveNote will idempotently re-run
+      // ensureNoteUuid internally; the only cost is one extra parse.
+      const { uuid } = ensureNoteUuid(args.content as string);
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'edit', path: args.path as string, uuid },
+        context,
+      );
 
       const outcome = await saveNote({
         path: args.path as string,
@@ -126,15 +159,20 @@ export const codexMutationFields: Record<
     args: {
       path: { type: new GraphQLNonNull(GraphQLString) },
       content: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        defaultMessage('Create', args.path as string, context);
+      const { uuid } = ensureNoteUuid(args.content as string);
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'create', path: args.path as string, uuid },
+        context,
+      );
 
       const outcome = await saveNote({
         path: args.path as string,
@@ -154,19 +192,26 @@ export const codexMutationFields: Record<
     args: {
       oldPath: { type: new GraphQLNonNull(GraphQLString) },
       newPath: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        `Rename ${args.oldPath as string} → ${args.newPath as string} via ${context.editedVia ?? 'Ostracon'}`;
+      const oldPath = args.oldPath as string;
+      const newPath = args.newPath as string;
+      const meta = await getNoteMeta(oldPath);
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'rename', path: oldPath, newPath, uuid: meta?.uuid },
+        context,
+      );
 
       const outcome = await renameNote({
-        oldPath: args.oldPath as string,
-        newPath: args.newPath as string,
+        oldPath,
+        newPath,
         author: authorFromUser(user),
         commitMessage: message,
       });
@@ -180,18 +225,24 @@ export const codexMutationFields: Record<
       'Delete a vault note. Returns the list of paths that linked to the deleted note (now orphan links) so the UI can warn the user.',
     args: {
       path: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.delete');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        defaultMessage('Delete', args.path as string, context);
+      const targetPath = args.path as string;
+      const meta = await getNoteMeta(targetPath);
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'delete', path: targetPath, uuid: meta?.uuid },
+        context,
+      );
 
       const outcome = await deleteNote({
-        path: args.path as string,
+        path: targetPath,
         author: authorFromUser(user),
         commitMessage: message,
       });
@@ -204,15 +255,19 @@ export const codexMutationFields: Record<
     description: 'Create a new vault folder. mkdir + drop a .gitkeep so git tracks the otherwise-empty directory.',
     args: {
       path: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        defaultMessage('Create folder', args.path as string, context);
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'create-folder', path: args.path as string },
+        context,
+      );
 
       const outcome = await createFolder({
         path: args.path as string,
@@ -230,15 +285,23 @@ export const codexMutationFields: Record<
     args: {
       oldPath: { type: new GraphQLNonNull(GraphQLString) },
       newPath: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        `Rename folder ${args.oldPath as string} → ${args.newPath as string} via ${context.editedVia ?? 'Ostracon'}`;
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        {
+          verb: 'rename-folder',
+          path: args.oldPath as string,
+          newPath: args.newPath as string,
+        },
+        context,
+      );
 
       const outcome = await renameFolder({
         oldPath: args.oldPath as string,
@@ -257,15 +320,19 @@ export const codexMutationFields: Record<
     args: {
       path: { type: new GraphQLNonNull(GraphQLString) },
       force: { type: GraphQLBoolean },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.delete');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        defaultMessage('Delete folder', args.path as string, context);
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'delete-folder', path: args.path as string },
+        context,
+      );
 
       const outcome = await deleteFolder({
         path: args.path as string,
@@ -284,19 +351,26 @@ export const codexMutationFields: Record<
     args: {
       oldPath: { type: new GraphQLNonNull(GraphQLString) },
       newParentPath: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        `Move ${args.oldPath as string} → ${args.newParentPath as string} via ${context.editedVia ?? 'Ostracon'}`;
+      const oldPath = args.oldPath as string;
+      const newParentPath = args.newParentPath as string;
+      const meta = await getNoteMeta(oldPath);
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'move', path: oldPath, newPath: newParentPath, uuid: meta?.uuid },
+        context,
+      );
 
       const outcome = await moveNote({
-        oldPath: args.oldPath as string,
-        newParentPath: args.newParentPath as string,
+        oldPath,
+        newParentPath,
         author: authorFromUser(user),
         commitMessage: message,
       });
@@ -311,15 +385,23 @@ export const codexMutationFields: Record<
     args: {
       oldPath: { type: new GraphQLNonNull(GraphQLString) },
       newParentPath: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        `Move folder ${args.oldPath as string} → ${args.newParentPath as string} via ${context.editedVia ?? 'Ostracon'}`;
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        {
+          verb: 'move-folder',
+          path: args.oldPath as string,
+          newPath: args.newParentPath as string,
+        },
+        context,
+      );
 
       const outcome = await moveFolder({
         oldPath: args.oldPath as string,
@@ -338,20 +420,26 @@ export const codexMutationFields: Record<
     args: {
       path: { type: new GraphQLNonNull(GraphQLString) },
       sha: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
 
-      const sha = args.sha as string;
-      const message =
-        (args.commitMessage as string | undefined)?.trim() ||
-        `Revert ${args.path as string} to ${sha.slice(0, 7)} via ${context.editedVia ?? 'Ostracon'}`;
+      const targetPath = args.path as string;
+      const toSha = args.sha as string;
+      const meta = await getNoteMeta(targetPath);
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'revert', path: targetPath, toSha, uuid: meta?.uuid },
+        context,
+      );
 
       const outcome = await revertNote({
-        path: args.path as string,
-        sha,
+        path: targetPath,
+        sha: toSha,
         author: authorFromUser(user),
         commitMessage: message,
       });
@@ -371,11 +459,22 @@ export const codexMutationFields: Record<
       wholeWord: { type: GraphQLBoolean },
       wikilinkAware: { type: GraphQLBoolean },
       pathScope: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        {
+          verb: 'find-replace',
+          path: `${args.query as string} → ${args.replacement as string}`,
+        },
+        context,
+      );
 
       const outcome = await applyVaultReplacement({
         query: args.query as string,
@@ -386,7 +485,7 @@ export const codexMutationFields: Record<
         wikilinkAware: (args.wikilinkAware as boolean | undefined) ?? false,
         pathScope: (args.pathScope as string[] | undefined) ?? undefined,
         author: authorFromUser(user),
-        commitMessage: (args.commitMessage as string | undefined) ?? undefined,
+        commitMessage: message,
       });
       return applyOutcomeToPayload(outcome);
     },
@@ -399,16 +498,29 @@ export const codexMutationFields: Record<
     args: {
       oldTag: { type: new GraphQLNonNull(GraphQLString) },
       newTag: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.write');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        {
+          verb: 'rename-tag',
+          path: args.oldTag as string,
+          newPath: args.newTag as string,
+        },
+        context,
+      );
+
       const outcome = await renameTag({
         oldTag: args.oldTag as string,
         newTag: args.newTag as string,
         author: authorFromUser(user),
-        commitMessage: (args.commitMessage as string | undefined) ?? undefined,
+        commitMessage: message,
       });
       return tagMutationOutcomeToPayload(outcome);
     },
@@ -420,15 +532,24 @@ export const codexMutationFields: Record<
       'Remove a tag from every note frontmatter. Single atomic commit. Auto-managed notes skipped.',
     args: {
       tag: { type: new GraphQLNonNull(GraphQLString) },
+      userMessage: { type: GraphQLString },
       commitMessage: { type: GraphQLString },
     },
     resolve: async (_parent, args, context) => {
       const user = await requireCodexPermission(context, 'codex.delete');
       if (!(await vaultExists())) throw new Error('Vault not found on this server.');
+
+      const message = commitMessageFor(
+        args.commitMessage as string | undefined,
+        args.userMessage as string | undefined,
+        { verb: 'delete-tag', path: args.tag as string },
+        context,
+      );
+
       const outcome = await deleteTag({
         tag: args.tag as string,
         author: authorFromUser(user),
-        commitMessage: (args.commitMessage as string | undefined) ?? undefined,
+        commitMessage: message,
       });
       return tagMutationOutcomeToPayload(outcome);
     },

--- a/src/server/__tests__/commit-format.test.ts
+++ b/src/server/__tests__/commit-format.test.ts
@@ -1,0 +1,192 @@
+// Unit tests for buildCodexCommitMessage.
+//
+// The structure of every commit produced by Ostracon's mutation
+// resolvers is here. Downstream tooling (audit log, search-index
+// sync, MCP audit) parses these messages — keep the shape contract
+// tight.
+
+import { describe, it, expect } from 'vitest';
+import { buildCodexCommitMessage } from '../commit-format';
+
+describe('buildCodexCommitMessage — subject lines', () => {
+  it('builds an edit subject with the basename + host tag', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'edit',
+      path: '20 - Products/NexaDeck.md',
+      editedVia: 'HallOfRecords v1',
+    });
+    expect(msg.split('\n')[0]).toBe('edit: NexaDeck.md via HallOfRecords v1');
+  });
+
+  it('falls back to "Ostracon" when editedVia is omitted', () => {
+    const msg = buildCodexCommitMessage({ verb: 'edit', path: 'Foo.md' });
+    expect(msg.split('\n')[0]).toBe('edit: Foo.md via Ostracon');
+  });
+
+  it('truncates long subjects to stay under 72 chars', () => {
+    const veryLongName = 'A'.repeat(120) + '.md';
+    const msg = buildCodexCommitMessage({
+      verb: 'edit',
+      path: veryLongName,
+      editedVia: 'Tag',
+    });
+    const subject = msg.split('\n')[0];
+    expect(subject.length).toBeLessThanOrEqual(72);
+    expect(subject.endsWith(' via Tag')).toBe(true);
+    expect(subject).toContain('…');
+  });
+
+  it('uses arrow + new basename for rename', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'rename',
+      path: '20 - Products/Old.md',
+      newPath: '20 - Products/New.md',
+      editedVia: 'Host',
+    });
+    expect(msg.split('\n')[0]).toBe('rename: Old.md → New.md via Host');
+  });
+
+  it('uses short SHA for revert', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'revert',
+      path: 'X.md',
+      toSha: 'abcdef1234567890',
+      editedVia: 'Host',
+    });
+    expect(msg.split('\n')[0]).toBe('revert: X.md to abcdef1 via Host');
+  });
+
+  it('uses query → replacement for find-replace', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'find-replace',
+      path: 'foo → bar',
+      editedVia: 'Host',
+    });
+    expect(msg.split('\n')[0]).toBe('find-replace: foo → bar via Host');
+  });
+});
+
+describe('buildCodexCommitMessage — body + trailers', () => {
+  it('includes user message as the body when provided', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'edit',
+      path: 'X.md',
+      userMessage: 'Clarified the kwa cue.',
+      editedVia: 'Host',
+    });
+    const sections = msg.split('\n\n');
+    expect(sections[1]).toBe('Clarified the kwa cue.');
+  });
+
+  it('skips the body when userMessage is empty/undefined', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'edit',
+      path: 'X.md',
+      editedVia: 'Host',
+    });
+    const sections = msg.split('\n\n');
+    expect(sections).toHaveLength(2); // subject + trailers, no body
+  });
+
+  it('emits standard trailers for note ops', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'edit',
+      path: '20 - Products/NexaDeck.md',
+      uuid: '0190f3b5-2c3a-7f4a-8a6c-9d3e1f5a4b62',
+      editedVia: 'HallOfRecords v1',
+    });
+    expect(msg).toContain('Note-Path: 20 - Products/NexaDeck.md');
+    expect(msg).toContain('Note-UUID: 0190f3b5-2c3a-7f4a-8a6c-9d3e1f5a4b62');
+    expect(msg).toContain('Edited-Via: HallOfRecords v1');
+  });
+
+  it('omits Note-UUID when uuid is absent', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'edit',
+      path: 'X.md',
+      editedVia: 'Host',
+    });
+    expect(msg).not.toContain('Note-UUID:');
+    expect(msg).toContain('Note-Path: X.md');
+    expect(msg).toContain('Edited-Via: Host');
+  });
+
+  it('emits Note-New-Path on rename/move', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'rename',
+      path: 'A.md',
+      newPath: 'B.md',
+      editedVia: 'Host',
+    });
+    expect(msg).toContain('Note-Path: A.md');
+    expect(msg).toContain('Note-New-Path: B.md');
+  });
+
+  it('emits Revert-To-SHA on revert', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'revert',
+      path: 'X.md',
+      toSha: 'deadbeefcafebabe',
+      editedVia: 'Host',
+    });
+    expect(msg).toContain('Revert-To-SHA: deadbeefcafebabe');
+  });
+
+  it('uses Folder-Path trailer for folder ops (no Note-Path)', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'rename-folder',
+      path: '20 - Products',
+      newPath: '20 - Apps',
+      editedVia: 'Host',
+    });
+    expect(msg).toContain('Folder-Path: 20 - Products');
+    expect(msg).toContain('Folder-New-Path: 20 - Apps');
+    expect(msg).not.toContain('Note-Path:');
+  });
+
+  it('uses Tag trailer for tag ops', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'rename-tag',
+      path: 'oldtag',
+      newPath: 'newtag',
+      editedVia: 'Host',
+    });
+    expect(msg).toContain('Tag: oldtag');
+    expect(msg).toContain('Tag-New: newtag');
+  });
+
+  it('emits no Note-Path / Folder-Path / Tag trailer for find-replace', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'find-replace',
+      path: 'foo → bar',
+      editedVia: 'Host',
+    });
+    expect(msg).not.toContain('Note-Path:');
+    expect(msg).not.toContain('Folder-Path:');
+    expect(msg).not.toContain('Tag:');
+    expect(msg).toContain('Edited-Via: Host');
+  });
+});
+
+describe('buildCodexCommitMessage — full output shape', () => {
+  it('emits subject, blank, body, blank, trailers', () => {
+    const msg = buildCodexCommitMessage({
+      verb: 'edit',
+      path: '20 - Products/NexaDeck.md',
+      uuid: '0190f3b5-2c3a-7f4a-8a6c-9d3e1f5a4b62',
+      userMessage: 'Clarified the kwa cue.',
+      editedVia: 'HallOfRecords v1',
+    });
+    expect(msg).toBe(
+      [
+        'edit: NexaDeck.md via HallOfRecords v1',
+        '',
+        'Clarified the kwa cue.',
+        '',
+        'Note-Path: 20 - Products/NexaDeck.md',
+        'Note-UUID: 0190f3b5-2c3a-7f4a-8a6c-9d3e1f5a4b62',
+        'Edited-Via: HallOfRecords v1',
+      ].join('\n'),
+    );
+  });
+});

--- a/src/server/commit-format.ts
+++ b/src/server/commit-format.ts
@@ -1,0 +1,164 @@
+// Standardized commit-message format for vault edits.
+//
+// Goals:
+//   • Subject lines stay scannable in `git log --oneline` (≤ 72 chars).
+//   • Trailers follow the git convention (parseable by
+//     `git interpret-trailers --parse`) so downstream tooling — audit
+//     log, search-index sync, MCP audit — can reliably extract the
+//     note path and uuid from any commit.
+//   • Body is the user's free-text reason (optional). When absent, the
+//     subject + trailers stand alone.
+//
+// Example output:
+//
+//   edit: NexaDeck.md via HallOfRecords v1
+//
+//   Clarified the distinction between peng-as-quality and peng-as-direction.
+//
+//   Note-Path: 20 - Products/NexaDeck.md
+//   Note-UUID: 0190f3b5-2c3a-7f4a-8a6c-9d3e1f5a4b62
+//   Edited-Via: HallOfRecords v1
+//
+// The buildCodexCommitMessage helper produces this consistently. Hosts
+// can build messages themselves and pass them via opts.commitMessage; if
+// they don't, the resolvers in @chriscase/ostracon/graphql call this
+// helper with the same input.
+
+export type CodexCommitVerb =
+  | 'edit'
+  | 'create'
+  | 'rename'
+  | 'move'
+  | 'delete'
+  | 'create-folder'
+  | 'rename-folder'
+  | 'delete-folder'
+  | 'move-folder'
+  | 'revert'
+  | 'find-replace'
+  | 'rename-tag'
+  | 'delete-tag';
+
+export interface CodexCommitInput {
+  verb: CodexCommitVerb;
+  /** Primary subject — note path, folder path, or tag name. */
+  path: string;
+  /** For rename / move ops: the destination path. */
+  newPath?: string;
+  /** For revert: the SHA the note is being reverted to. */
+  toSha?: string;
+  /** Stable UUID of the affected note, when known. Omitted from the
+   *  trailers when absent (e.g., during the brief pre-backfill window
+   *  on existing vaults, or for folder-level ops). */
+  uuid?: string | null;
+  /** Optional user-provided reason — becomes the commit body. */
+  userMessage?: string;
+  /** Host tag (e.g., "HallOfRecords v1", "Abydonian admin"). Used in
+   *  the subject + the `Edited-Via:` trailer. Defaults to "Ostracon"
+   *  when omitted. */
+  editedVia?: string;
+}
+
+const SUBJECT_LIMIT = 72;
+
+function basename(p: string): string {
+  const i = p.lastIndexOf('/');
+  return i >= 0 ? p.slice(i + 1) : p;
+}
+
+function buildSubject(input: CodexCommitInput): string {
+  const via = input.editedVia ?? 'Ostracon';
+  const suffix = ` via ${via}`;
+
+  function fit(body: string): string {
+    const subject = `${body}${suffix}`;
+    if (subject.length <= SUBJECT_LIMIT) return subject;
+    // Truncate just the body (keep verb + " via X" intact).
+    const room = SUBJECT_LIMIT - suffix.length;
+    if (room <= 4) return subject; // suffix already too long; give up gracefully
+    return `${body.slice(0, room - 1).trimEnd()}…${suffix}`;
+  }
+
+  switch (input.verb) {
+    case 'edit':
+    case 'create':
+    case 'delete':
+    case 'create-folder':
+    case 'delete-folder':
+      return fit(`${input.verb}: ${basename(input.path)}`);
+    case 'rename':
+    case 'move':
+    case 'rename-folder':
+    case 'move-folder':
+      return fit(
+        `${input.verb}: ${basename(input.path)} → ${basename(input.newPath ?? '')}`,
+      );
+    case 'revert':
+      return fit(
+        `revert: ${basename(input.path)} to ${(input.toSha ?? '').slice(0, 7)}`,
+      );
+    case 'find-replace':
+      return fit(`find-replace: ${input.path}`);
+    case 'rename-tag':
+      return fit(`rename-tag: ${input.path} → ${input.newPath ?? ''}`);
+    case 'delete-tag':
+      return fit(`delete-tag: ${input.path}`);
+  }
+}
+
+function buildTrailers(input: CodexCommitInput): string[] {
+  const via = input.editedVia ?? 'Ostracon';
+  const lines: string[] = [];
+
+  // Folder / tag ops don't anchor to a single note UUID — use the
+  // appropriate trailer key for clarity.
+  switch (input.verb) {
+    case 'create-folder':
+    case 'rename-folder':
+    case 'delete-folder':
+    case 'move-folder':
+      lines.push(`Folder-Path: ${input.path}`);
+      if (input.newPath) lines.push(`Folder-New-Path: ${input.newPath}`);
+      break;
+    case 'rename-tag':
+    case 'delete-tag':
+      lines.push(`Tag: ${input.path}`);
+      if (input.newPath) lines.push(`Tag-New: ${input.newPath}`);
+      break;
+    case 'find-replace':
+      // No anchor path; the apply outcome already lists changed files.
+      break;
+    default:
+      lines.push(`Note-Path: ${input.path}`);
+      if (input.newPath) lines.push(`Note-New-Path: ${input.newPath}`);
+      if (input.uuid) lines.push(`Note-UUID: ${input.uuid}`);
+      if (input.verb === 'revert' && input.toSha) {
+        lines.push(`Revert-To-SHA: ${input.toSha}`);
+      }
+      break;
+  }
+
+  lines.push(`Edited-Via: ${via}`);
+  return lines;
+}
+
+/**
+ * Build a standardized commit message for a codex mutation. Hosts can
+ * call this directly when they want a particular format upfront;
+ * Ostracon's mutation resolvers call it as a fallback when the caller
+ * doesn't supply a custom commitMessage.
+ *
+ * The output is git-trailer compatible — every machine-readable field
+ * after the first blank line passes `git interpret-trailers --parse`.
+ */
+export function buildCodexCommitMessage(input: CodexCommitInput): string {
+  const subject = buildSubject(input);
+  const trailers = buildTrailers(input);
+  const userBody = input.userMessage?.trim();
+
+  // Format: <subject>\n\n[<userBody>\n\n]<trailers...>
+  const sections: string[] = [subject];
+  if (userBody) sections.push(userBody);
+  sections.push(trailers.join('\n'));
+  return sections.join('\n\n');
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -39,6 +39,8 @@ export * from './find-replace';
 export * from './auto-managed';
 export * from './user-prefs';
 export * from './config';
+export * from './uuid';
+export * from './commit-format';
 export {
   getFileHistory,
   readFileAtSha,

--- a/src/server/sync.ts
+++ b/src/server/sync.ts
@@ -49,15 +49,19 @@ import { generateUuidV7, isValidUuid } from './uuid';
  * a fresh v7 UUID and re-serialize. Idempotent — content that already has
  * a valid UUID round-trips unchanged.
  *
- * Used by saveNote and friends so every committed note carries a stable
- * identifier from its first write. Anchors comments, annotations,
- * embeddings, audit-log entries.
+ * Returns both the (possibly-modified) content and the UUID, so callers
+ * that want to reference the UUID in a commit message don't have to
+ * re-parse. Used by saveNote and by the GraphQL mutation layer when it
+ * needs the UUID to populate the `Note-UUID:` trailer.
  */
-function ensureNoteUuid(content: string): string {
+export function ensureNoteUuid(content: string): { content: string; uuid: string } {
   const parsed = parseNote(content);
-  if (isValidUuid(parsed.data.uuid)) return content;
-  parsed.data.uuid = generateUuidV7();
-  return serializeNote(parsed.data, parsed.content);
+  if (isValidUuid(parsed.data.uuid)) {
+    return { content, uuid: parsed.data.uuid };
+  }
+  const uuid = generateUuidV7();
+  parsed.data.uuid = uuid;
+  return { content: serializeNote(parsed.data, parsed.content), uuid };
 }
 
 export type SaveOutcome =
@@ -133,7 +137,7 @@ export async function saveNote(opts: SaveOptions): Promise<SaveOutcome> {
     // on subsequent saves — content that already has a valid uuid round-
     // trips unchanged. Done before the secret scan + no-op check so the
     // value we scan + write + hash is the final on-disk form.
-    const finalContent = ensureNoteUuid(opts.content);
+    const { content: finalContent } = ensureNoteUuid(opts.content);
 
     const hits = scanContent(finalContent);
     if (hits.length > 0) {


### PR DESCRIPTION
## Summary

Every codex mutation now emits a structured commit message with subject + optional body + git trailers (\`Note-Path:\`, \`Note-UUID:\`, \`Edited-Via:\`, \`Folder-Path:\`, etc.).

Supports chriscase/AbydosTemple#108 (per-user attribution) by giving the platform a stable, machine-parseable commit format. Downstream tooling — audit log, search-index sync, MCP audit — can extract every field via \`git interpret-trailers --parse\` instead of regexing the subject line.

## Example

\`\`\`
edit: NexaDeck.md via HallOfRecords v1

Clarified the distinction between peng-as-quality and peng-as-direction.

Note-Path: 20 - Products/NexaDeck.md
Note-UUID: 0190f3b5-2c3a-7f4a-8a6c-9d3e1f5a4b62
Edited-Via: HallOfRecords v1
\`\`\`

## Surface

- \`src/server/commit-format.ts\` — \`buildCodexCommitMessage(input)\` helper + types
- New GraphQL arg \`userMessage: String\` on every write mutation (the optional \"Why?\" field a UI would expose)
- Legacy \`commitMessage\` arg still overrides verbatim (back-compat for scripts)
- \`ensureNoteUuid\` exported and returns \`{ content, uuid }\` so the GraphQL layer can include the \`Note-UUID:\` trailer without re-parsing

## Trailer shapes by verb

| Verb | Trailers |
|------|----------|
| edit / create / delete | Note-Path, Note-UUID?, Edited-Via |
| rename / move | Note-Path, Note-New-Path, Note-UUID?, Edited-Via |
| revert | Note-Path, Note-UUID?, Revert-To-SHA, Edited-Via |
| create-folder / delete-folder | Folder-Path, Edited-Via |
| rename-folder / move-folder | Folder-Path, Folder-New-Path, Edited-Via |
| rename-tag | Tag, Tag-New, Edited-Via |
| delete-tag | Tag, Edited-Via |
| find-replace | Edited-Via only (apply outcome lists changed files) |

## Test plan

- [x] \`npm run type-check\` clean
- [x] 231/231 vitest pass (17 new + 214 prior)
- [x] commit-format.test covers: subject truncation under 72 chars, every verb's subject shape, body-present vs body-absent, every trailer key, full integration shape
- [x] schema.contract.test verifies every write mutation accepts \`userMessage\`

## Follow-up

- HoR PR #117 already shipped the turnkey schema import; refreshing the Ostracon ref will pick up these new args automatically. UI work (the \"Why?\" input field + nicer HistoryPanel author display) is a follow-on AbydosTemple PR per #108.