### PR TITLE
fix(graph): mobile fallback respects scope + noteFocus

### DIFF
--- a/src/ui/CodexGraph.tsx
+++ b/src/ui/CodexGraph.tsx
@@ -466,7 +466,14 @@ export default function CodexGraph({ scope, noteFocus, noteFocusDepth = 2 }: Pro
     sigma.refresh();
   }, [search, folderFilter, hoveredId]);
 
-  if (isMobile) return <MobileFallback />;
+  if (isMobile)
+    return (
+      <MobileFallback
+        scope={scope}
+        noteFocus={noteFocus}
+        noteFocusDepth={noteFocusDepth}
+      />
+    );
   if (error) return <div className={styles.error}>{error}</div>;
   if (!data) return <div className={styles.spinnerWrap}>Loading graph…</div>;
 
@@ -946,27 +953,94 @@ function nodeSize(n: CodexGraphNode): number {
   return Math.max(3, Math.min(20, Math.sqrt(n.pageRank * 4500)));
 }
 
-function MobileFallback() {
+// ─── Mobile fallback ─────────────────────────────────────────────────────────
+//
+// Sigma's WebGL canvas + force-directed layout is poor at <= 768px (labels
+// unreadable, pan/zoom fights browser scroll, FPS drops). Instead we render
+// the same information as a touch-friendly ranked list. Behavior matches the
+// three desktop graph views:
+//
+//   • Full vault (no scope, no noteFocus): top folders by influence — tap
+//     drills into the folder.
+//   • Folder scope: notes in the folder ranked by influence — tap opens the
+//     note's linkages page.
+//   • Note focus (linkages): connected notes grouped by hop distance — same
+//     content as the desktop side panel, tap pivots onto another note.
+
+interface MobileFallbackProps {
+  scope?: string | null;
+  noteFocus?: string;
+  noteFocusDepth?: number;
+}
+
+interface MobileGraphRow {
+  id: string;
+  label: string;
+  folder: string;
+  pageRank: number;
+  distance?: number | null;
+  noteCount?: number | null;
+}
+
+function MobileFallback({ scope, noteFocus, noteFocusDepth = 2 }: MobileFallbackProps) {
   const graphqlRequest = useCodexGraphqlRequest();
-  const [hits, setHits] = useState<Array<{ id: string; label: string; pageRank: number }>>([]);
+  const { useRouter: useNavRouter } = useCodexNavigation();
+  const router = useNavRouter();
+  const [rows, setRows] = useState<MobileGraphRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    setLoading(true);
+    setError(null);
+
     (async () => {
       try {
-        const { data, errors } = await graphqlRequest<{
-          vaultGraph: { nodes: Array<{ id: string; label: string; pageRank: number }> };
-        }>(TOP_NOTES_QUERY);
-        if (cancelled) return;
-        if (errors?.length) {
-          setError(errors.map((e) => e.message).join('; '));
+        if (noteFocus) {
+          const { data, errors } = await graphqlRequest<{
+            vaultNoteNeighborhood: CodexGraphPayload;
+          }>(NOTE_NEIGHBORHOOD_QUERY, { notePath: noteFocus, depth: noteFocusDepth });
+          if (cancelled) return;
+          if (errors?.length) {
+            setError(errors.map((e) => e.message).join('; '));
+          } else {
+            const nodes = data?.vaultNoteNeighborhood.nodes ?? [];
+            setRows(
+              nodes
+                .filter((n) => n.id !== noteFocus) // exclude focus node itself
+                .sort(byDistanceThenLabel)
+                .map((n) => ({
+                  id: n.id,
+                  label: n.label,
+                  folder: n.folder,
+                  pageRank: n.pageRank,
+                  distance: n.distance,
+                })),
+            );
+          }
         } else {
-          const sorted = (data?.vaultGraph.nodes ?? [])
-            .slice()
-            .sort((a, b) => b.pageRank - a.pageRank);
-          setHits(sorted);
+          const { data, errors } = await graphqlRequest<{
+            vaultGraph: CodexGraphPayload;
+          }>(GRAPH_QUERY, { scope: scope ?? null });
+          if (cancelled) return;
+          if (errors?.length) {
+            setError(errors.map((e) => e.message).join('; '));
+          } else {
+            const nodes = data?.vaultGraph.nodes ?? [];
+            setRows(
+              nodes
+                .slice()
+                .sort((a, b) => b.pageRank - a.pageRank)
+                .map((n) => ({
+                  id: n.id,
+                  label: n.label,
+                  folder: n.folder,
+                  pageRank: n.pageRank,
+                  noteCount: n.noteCount,
+                })),
+            );
+          }
         }
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load');
@@ -974,29 +1048,132 @@ function MobileFallback() {
         if (!cancelled) setLoading(false);
       }
     })();
+
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [scope, noteFocus, noteFocusDepth]);
+
+  const onTap = useCallback(
+    (row: MobileGraphRow) => {
+      if (noteFocus || scope) {
+        // Note-level row → open its linkages page.
+        const url =
+          '/admin/codex/graph/note/' +
+          row.id
+            .replace(/\.md$/i, '')
+            .split(/[\\/]/g)
+            .map((seg) => encodeURIComponent(seg))
+            .join('/');
+        router.push(url);
+      } else {
+        // Folder-level row → drill into that folder's graph.
+        router.push(`/admin/codex/graph?scope=${encodeURIComponent(row.id)}`);
+      }
+    },
+    [noteFocus, scope, router],
+  );
 
   if (loading) return <div className={styles.spinnerWrap}>Loading…</div>;
   if (error) return <div className={styles.error}>{error}</div>;
 
+  // Group note-focus rows by hop distance ("Direct" / "Further out").
+  const directConnections = noteFocus ? rows.filter((r) => (r.distance ?? 0) === 1) : [];
+  const widerConnections = noteFocus ? rows.filter((r) => (r.distance ?? 0) >= 2) : [];
+
+  const focusLabel = noteFocus ? noteFocus.split('/').pop()?.replace(/\.md$/i, '') ?? noteFocus : '';
+
   return (
     <div className={styles.mobileGraphFallback}>
-      <h3>Top folders by influence</h3>
-      <p style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
-        The interactive graph is hidden on small screens. Open this page on a wider viewport
-        to explore the link graph visually.
-      </p>
-      <ul className={styles.mobileFolderList}>
-        {hits.map((h) => (
-          <li key={h.id}>
-            <strong>{h.label}</strong>
-            <span className={styles.notePath}>influence {(h.pageRank * 100).toFixed(2)}</span>
+      {noteFocus ? (
+        <>
+          <h3>Linkages from {focusLabel}</h3>
+          <p className={styles.mobileGraphSubtitle}>
+            {rows.length} connected · depth {noteFocusDepth}
+          </p>
+          {directConnections.length > 0 && (
+            <MobileRowSection
+              heading="Direct connections"
+              rows={directConnections}
+              onTap={onTap}
+            />
+          )}
+          {widerConnections.length > 0 && (
+            <MobileRowSection
+              heading="Further out"
+              rows={widerConnections}
+              onTap={onTap}
+            />
+          )}
+          {rows.length === 0 && (
+            <p className={styles.mobileGraphSubtitle}>
+              No linkages at this depth.
+            </p>
+          )}
+        </>
+      ) : scope ? (
+        <>
+          <h3>{scope}</h3>
+          <p className={styles.mobileGraphSubtitle}>
+            {rows.length} note{rows.length === 1 ? '' : 's'} · tap to view linkages
+          </p>
+          <MobileRowSection rows={rows} onTap={onTap} />
+        </>
+      ) : (
+        <>
+          <h3>Top folders by influence</h3>
+          <p className={styles.mobileGraphSubtitle}>Tap a folder to drill in</p>
+          <MobileRowSection rows={rows} onTap={onTap} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function MobileRowSection({
+  heading,
+  rows,
+  onTap,
+}: {
+  heading?: string;
+  rows: MobileGraphRow[];
+  onTap: (row: MobileGraphRow) => void;
+}) {
+  return (
+    <section className={styles.mobileGraphSection}>
+      {heading && (
+        <h4 className={styles.mobileGraphSectionHeading}>
+          {heading} <span className={styles.mobileGraphSectionCount}>{rows.length}</span>
+        </h4>
+      )}
+      <ul className={styles.mobileGraphList}>
+        {rows.map((row) => (
+          <li key={row.id}>
+            <button
+              type="button"
+              className={styles.mobileGraphRow}
+              onClick={() => onTap(row)}
+            >
+              <span className={styles.mobileGraphRowLabel}>{row.label}</span>
+              <span className={styles.mobileGraphRowMeta}>
+                {row.distance !== undefined
+                  ? `${row.distance} hop${row.distance === 1 ? '' : 's'}`
+                  : row.noteCount !== undefined
+                  ? `${row.noteCount} notes`
+                  : row.folder
+                  ? row.folder.replace(/^\d+\s*-\s*/, '')
+                  : ''}
+              </span>
+              <span className={styles.mobileGraphRowChevron} aria-hidden="true">›</span>
+            </button>
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   );
+}
+
+function byDistanceThenLabel(a: CodexGraphNode, b: CodexGraphNode): number {
+  const d = (a.distance ?? 0) - (b.distance ?? 0);
+  return d !== 0 ? d : a.label.localeCompare(b.label);
 }

--- a/src/ui/codex.module.css
+++ b/src/ui/codex.module.css
@@ -999,31 +999,104 @@
 }
 
 .mobileGraphFallback {
-  padding: 1rem 0.5rem;
+  padding: 1rem 0.75rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .mobileGraphFallback h3 {
-  margin: 0 0 0.5rem 0;
-  font-size: 1rem;
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
 }
 
-.mobileFolderList {
-  list-style: none;
-  margin: 1rem 0 0 0;
-  padding: 0;
-  font-size: 0.875rem;
+.mobileGraphSubtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
 }
 
-.mobileFolderList li {
+.mobileGraphSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.mobileGraphSectionHeading {
+  margin: 0.4rem 0 0.1rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0;
-  border-bottom: 1px solid var(--border);
+  gap: 0.4rem;
 }
 
-.mobileFolderList strong {
+.mobileGraphSectionCount {
+  font-size: 0.7rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.mobileGraphList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.mobileGraphRow {
+  width: 100%;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  text-align: left;
+  cursor: pointer;
+  /* Active-feedback on tap for iOS / Android. */
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 100ms ease, border-color 100ms ease;
+}
+
+.mobileGraphRow:active {
+  background: rgba(120, 200, 255, 0.12);
+  border-color: rgba(120, 200, 255, 0.45);
+}
+
+.mobileGraphRowLabel {
   flex: 1;
+  min-width: 0;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobileGraphRowMeta {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.mobileGraphRowChevron {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  line-height: 1;
 }
 
 /* ─── Editor + buttons + toasts (PR #203) ───────────────────── */


### PR DESCRIPTION
## Summary

The graph view's mobile fallback (under 768px) always rendered \"Top folders by influence\" regardless of route. After drilling into a folder or opening a note's linkages on mobile, the user got the same useless top-folders list — symptom reported as \"graph doesn't work on mobile.\"

## Root cause

\`MobileFallback\` was a parameterless component that issued a single \`vaultGraph(scope: null)\` query no matter the parent's props. Plus the row UI used 0.4rem-padded text (≈30px tall) — well under the 44px iOS / 48px Android touch-target floor, so anything that did render was awkward to tap.

## Fix

- \`MobileFallback\` now accepts \`scope\`, \`noteFocus\`, \`noteFocusDepth\` and queries the same endpoint the desktop graph would have hit:
  - **noteFocus** → \`vaultNoteNeighborhood\`, grouped by hop distance (Direct / Further out)
  - **scope** → \`vaultGraph(scope)\`, ranked by influence
  - **neither** → \`vaultGraph(null)\`, top folders
- Each row is a 48px-min-height card with label + meta + chevron, tap-activated style, ellipsis on overflow, no double-tap-to-zoom interference. Tap target meets iOS + Android guidelines.
- Section headings (\"Direct connections (12)\", \"Further out (84)\") mirror the desktop side panel.
- Title bar reflects what you're actually looking at — gone is the \"open on a wider viewport\" message; mobile is now a first-class surface, the list IS the view.

No behavior change on desktop (>= 768px). All 231 existing tests still pass.

## Test plan

- [x] \`npm run type-check\` clean
- [x] Full vitest: 231 / 231 pass
- [ ] After merge + HoR refresh: open temple.abydonian.com on iPhone Safari, hit the graph button — see top folders → tap a folder → see notes ranked → tap a note → see linkages grouped by hop distance