### PR TITLE
feat(adapters): Event / Search / Embeddings / Annotation contracts (#16, #19, #20, #23)

### DIFF
--- a/src/graphql/context.ts
+++ b/src/graphql/context.ts
@@ -20,10 +20,28 @@
 
 import type { PrismaClient } from '@prisma/client';
 import type { AuthAdapter } from '../server/auth-adapter';
+import type { EventAdapter } from '../server/event-adapter';
+import type { SearchAdapter } from '../server/search-adapter';
+import type { EmbeddingsAdapter } from '../server/embeddings-adapter';
+import type { AnnotationAdapter } from '../server/annotation-adapter';
 
 export interface CodexGraphQLContext {
   prisma: PrismaClient;
   codexAuth?: AuthAdapter;
+  /** Optional host adapter — receives every successful mutation event
+   *  so the host can keep derived state (search index, audit log,
+   *  embeddings) in sync. */
+  codexEvents?: EventAdapter;
+  /** Optional host adapter — when present, the search resolver delegates
+   *  to it; when absent, the resolver falls back to Ostracon's in-memory
+   *  substring + tag search. */
+  codexSearch?: SearchAdapter;
+  /** Optional host adapter — when present, semantic search modes light
+   *  up and concept-clustering / similarity features become available. */
+  codexEmbeddings?: EmbeddingsAdapter;
+  /** Optional host adapter — when present, the annotation/comment
+   *  GraphQL fields are populated. */
+  codexAnnotations?: AnnotationAdapter;
   /** Short tag interpolated into default commit messages. Hosts override
    *  this to attribute commits to a specific frontend (e.g. "HallOfRecords
    *  v1"). When undefined, falls back to "Ostracon". */

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -150,6 +150,8 @@ export const codexMutationFields: Record<
         baseSha: args.baseSha as string,
         author: authorFromUser(user),
         commitMessage: message,
+        events: context.codexEvents,
+        user,
       });
       return outcomeToPayload(outcome);
     },
@@ -182,6 +184,8 @@ export const codexMutationFields: Record<
         baseSha: null,
         author: authorFromUser(user),
         commitMessage: message,
+        events: context.codexEvents,
+        user,
       });
       return outcomeToPayload(outcome);
     },
@@ -216,6 +220,8 @@ export const codexMutationFields: Record<
         newPath,
         author: authorFromUser(user),
         commitMessage: message,
+        events: context.codexEvents,
+        user,
       });
       return renameOutcomeToPayload(outcome);
     },
@@ -247,6 +253,8 @@ export const codexMutationFields: Record<
         path: targetPath,
         author: authorFromUser(user),
         commitMessage: message,
+        events: context.codexEvents,
+        user,
       });
       return deleteOutcomeToPayload(outcome);
     },

--- a/src/server/__tests__/event-adapter.test.ts
+++ b/src/server/__tests__/event-adapter.test.ts
@@ -1,0 +1,221 @@
+// Contract tests for EventAdapter integration in the sync coordinator.
+// Verifies that a registered adapter receives the expected event shape
+// after each mutation. Filesystem-backed because the events fire from
+// inside the sync mutex against real git operations.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { saveNote, renameNote, deleteNote, _resetSyncForTest } from '../sync';
+import { invalidateIndex, contentSha } from '../vault-index';
+import { invalidatePageRank } from '../graph';
+import { resetGit } from '../git';
+import type { EventAdapter, VaultEvent } from '../event-adapter';
+
+const exec = promisify(execFile);
+
+let tmpRoot: string;
+let originalEnv: string | undefined;
+const author = { name: 'Test', email: 'test@test.com' };
+const user = { id: 'user-1', name: 'Test', email: 'test@test.com' };
+
+async function gitInit(dir: string): Promise<void> {
+  await exec('git', ['init', '-q', '-b', 'main', dir]);
+  await exec('git', ['-C', dir, 'config', 'user.name', author.name]);
+  await exec('git', ['-C', dir, 'config', 'user.email', author.email]);
+  await exec('git', ['-C', dir, 'config', 'commit.gpgsign', 'false']);
+}
+
+function recordingAdapter(): { adapter: EventAdapter; events: VaultEvent[] } {
+  const events: VaultEvent[] = [];
+  return {
+    events,
+    adapter: { emit: (e) => void events.push(e) },
+  };
+}
+
+beforeAll(async () => {
+  tmpRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'codex-events-')));
+  await gitInit(tmpRoot);
+  await fs.mkdir(path.join(tmpRoot, '20 - Products'), { recursive: true });
+  await fs.writeFile(path.join(tmpRoot, 'README.md'), '# Codex\n');
+  await exec('git', ['-C', tmpRoot, 'add', '.']);
+  await exec('git', ['-C', tmpRoot, 'commit', '-q', '-m', 'init']);
+  originalEnv = process.env.ABYDOS_VAULT_PATH;
+  process.env.ABYDOS_VAULT_PATH = tmpRoot;
+});
+
+beforeEach(async () => {
+  invalidateIndex();
+  invalidatePageRank();
+  resetGit();
+  await _resetSyncForTest();
+});
+
+afterEach(async () => {
+  await _resetSyncForTest();
+});
+
+afterAll(async () => {
+  if (originalEnv === undefined) delete process.env.ABYDOS_VAULT_PATH;
+  else process.env.ABYDOS_VAULT_PATH = originalEnv;
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('EventAdapter — saveNote', () => {
+  it('emits note.created on a brand-new file', async () => {
+    const { adapter, events } = recordingAdapter();
+    const outcome = await saveNote({
+      path: '20 - Products/EventCreate.md',
+      content: '---\ntags: [test]\n---\n\nbody',
+      baseSha: null,
+      author,
+      commitMessage: 'create',
+      events: adapter,
+      user,
+    });
+    expect(outcome.kind).toBe('OK');
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('note.created');
+    if (events[0].kind === 'note.created') {
+      expect(events[0].path).toBe('20 - Products/EventCreate.md');
+      expect(events[0].uuid).toMatch(/^[0-9a-f-]{36}$/);
+      expect(events[0].commitSha).toMatch(/^[0-9a-f]{40}$/);
+      expect(events[0].author.email).toBe('test@test.com');
+    }
+  });
+
+  it('emits note.saved on an update to an existing file', async () => {
+    const { adapter, events } = recordingAdapter();
+    // First, create.
+    const initial = await saveNote({
+      path: '20 - Products/EventUpdate.md',
+      content: '---\ntags: [test]\n---\n\nv1',
+      baseSha: null,
+      author,
+      commitMessage: 'create',
+      events: adapter,
+    });
+    expect(initial.kind).toBe('OK');
+    if (initial.kind !== 'OK') return;
+
+    // Then update with the new sha.
+    const after = await fs.readFile(
+      path.join(tmpRoot, '20 - Products/EventUpdate.md'),
+      'utf8',
+    );
+    const edited = after.replace('v1', 'v2');
+    const outcome = await saveNote({
+      path: '20 - Products/EventUpdate.md',
+      content: edited,
+      baseSha: contentSha(after),
+      author,
+      commitMessage: 'update',
+      events: adapter,
+    });
+    expect(outcome.kind).toBe('OK');
+    expect(events).toHaveLength(2);
+    expect(events[1].kind).toBe('note.saved');
+  });
+
+  it('does NOT emit on CONFLICT', async () => {
+    await fs.writeFile(
+      path.join(tmpRoot, '20 - Products/EventConflict.md'),
+      'existing',
+      'utf8',
+    );
+    await exec('git', ['-C', tmpRoot, 'add', '.']);
+    await exec('git', ['-C', tmpRoot, 'commit', '-q', '-m', 'conflict-fixture']);
+    const { adapter, events } = recordingAdapter();
+    const outcome = await saveNote({
+      path: '20 - Products/EventConflict.md',
+      content: 'new',
+      baseSha: 'wrong-sha',
+      author,
+      commitMessage: 'should-conflict',
+      events: adapter,
+    });
+    expect(outcome.kind).toBe('CONFLICT');
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('EventAdapter — renameNote', () => {
+  it('emits note.renamed with the original UUID + both paths', async () => {
+    const { adapter, events } = recordingAdapter();
+    await saveNote({
+      path: '20 - Products/EventRenameSrc.md',
+      content: '---\ntags: [test]\n---\n\nbody',
+      baseSha: null,
+      author,
+      commitMessage: 'create',
+      events: adapter,
+    });
+    const createdUuid = events[0].kind === 'note.created' ? events[0].uuid : null;
+    events.length = 0;
+
+    invalidateIndex();
+    const outcome = await renameNote({
+      oldPath: '20 - Products/EventRenameSrc.md',
+      newPath: '20 - Products/EventRenameDest.md',
+      author,
+      commitMessage: 'rename',
+      events: adapter,
+    });
+    expect(outcome.kind).toBe('OK');
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('note.renamed');
+    if (events[0].kind === 'note.renamed') {
+      expect(events[0].oldPath).toBe('20 - Products/EventRenameSrc.md');
+      expect(events[0].newPath).toBe('20 - Products/EventRenameDest.md');
+      expect(events[0].uuid).toBe(createdUuid);
+    }
+  });
+});
+
+describe('EventAdapter — deleteNote', () => {
+  it('emits note.deleted with the UUID of the deleted note', async () => {
+    const { adapter, events } = recordingAdapter();
+    await saveNote({
+      path: '20 - Products/EventDelete.md',
+      content: '---\ntags: [test]\n---\n\nbody',
+      baseSha: null,
+      author,
+      commitMessage: 'create',
+      events: adapter,
+    });
+    const createdUuid = events[0].kind === 'note.created' ? events[0].uuid : null;
+    events.length = 0;
+
+    invalidateIndex();
+    const outcome = await deleteNote({
+      path: '20 - Products/EventDelete.md',
+      author,
+      commitMessage: 'delete',
+      events: adapter,
+    });
+    expect(outcome.kind).toBe('OK');
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('note.deleted');
+    if (events[0].kind === 'note.deleted') {
+      expect(events[0].path).toBe('20 - Products/EventDelete.md');
+      expect(events[0].uuid).toBe(createdUuid);
+    }
+  });
+});
+
+describe('EventAdapter — no-op when adapter not supplied', () => {
+  it('saveNote succeeds without events when opts.events is omitted', async () => {
+    const outcome = await saveNote({
+      path: '20 - Products/EventNoneSupplied.md',
+      content: '---\ntags: [test]\n---\n\nbody',
+      baseSha: null,
+      author,
+      commitMessage: 'no-events',
+    });
+    expect(outcome.kind).toBe('OK');
+  });
+});

--- a/src/server/annotation-adapter.ts
+++ b/src/server/annotation-adapter.ts
@@ -1,0 +1,54 @@
+// AnnotationAdapter contract — host-pluggable comments / per-paragraph
+// annotations layer.
+//
+// Vault markdown stays the source of truth. Annotations are downstream
+// user-data that lives in the host's database, anchored by note UUID
+// (so they survive renames) and an optional paragraph hash (so they
+// can attach to specific lines).
+//
+// Default is no-op — when no adapter is registered, the annotation UI
+// is hidden and no GraphQL fields surface.
+
+import type { CodexUser } from './auth-adapter';
+
+export interface AnnotationAnchor {
+  noteUuid: string;
+  /** sha256(paragraph_text).slice(0,12). When null, the annotation
+   *  attaches to the whole note rather than a specific paragraph. */
+  paragraphAnchor?: string | null;
+}
+
+export interface AnnotationReaction {
+  emoji: string;
+  users: string[];
+}
+
+export interface Annotation {
+  id: string;
+  anchor: AnnotationAnchor;
+  author: CodexUser;
+  bodyMarkdown: string;
+  /** Server-rendered HTML — cached so the UI doesn't re-render markdown
+   *  on every read. Adapters may regenerate on edit. */
+  bodyHtml: string;
+  createdAt: string; // ISO 8601
+  updatedAt: string;
+  /** Parent annotation id for threading. null/undefined = top-level. */
+  parentId?: string | null;
+  reactions?: AnnotationReaction[];
+}
+
+export interface AnnotationAdapter {
+  listForNote(noteUuid: string): Promise<Annotation[]>;
+  create(input: {
+    anchor: AnnotationAnchor;
+    bodyMarkdown: string;
+    parentId?: string;
+    author: CodexUser;
+  }): Promise<Annotation>;
+  update(id: string, bodyMarkdown: string, author: CodexUser): Promise<Annotation>;
+  delete(id: string, author: CodexUser): Promise<void>;
+  /** Optional — adapters that support emoji reactions. */
+  react?(id: string, emoji: string, user: CodexUser): Promise<void>;
+  unreact?(id: string, emoji: string, user: CodexUser): Promise<void>;
+}

--- a/src/server/embeddings-adapter.ts
+++ b/src/server/embeddings-adapter.ts
@@ -1,0 +1,54 @@
+// EmbeddingsAdapter contract — host-pluggable vector index for
+// semantic search and concept clustering.
+//
+// Hosts wire their own embedding provider (Voyage AI, OpenAI, local,
+// Cohere, ...) and storage backend (pgvector, Pinecone, FAISS, ...).
+// Ostracon never makes outbound HTTP calls on its own; it just defines
+// the seam.
+//
+// Default is no-op — when no adapter is registered, semantic search
+// modes return an empty result set + the search UI hides the mode.
+
+import type { VaultEvent } from './event-adapter';
+
+export interface EmbeddingVector {
+  noteUuid: string;
+  /** Paragraph hash (sha256 of paragraph text, sliced to 12 chars).
+   *  When null/undefined, the vector represents the whole note. */
+  paragraphAnchor?: string | null;
+  vector: number[];
+}
+
+export interface SimilarityHit {
+  noteUuid: string;
+  path: string;
+  paragraphAnchor?: string | null;
+  /** Backend-dependent (cosine, dot-product, ...). Higher = more
+   *  similar by adapter convention. */
+  score: number;
+  /** Excerpt to render in the UI. Adapter that store per-paragraph
+   *  vectors should return the paragraph text here. */
+  excerpt?: string;
+}
+
+export interface EmbeddingsAdapter {
+  /** Embed an arbitrary text — used at query time. */
+  embed(text: string): Promise<number[]>;
+  /** (Re)index a single note. Implementations chunk content and store
+   *  one or more vectors. Called from the host's EventAdapter listener
+   *  on note.saved / note.created. */
+  indexNote(uuid: string, content: string): Promise<void>;
+  /** Remove all vectors for a deleted/renamed note. (Renames index the
+   *  new path then remove the old.) */
+  removeNote(uuid: string): Promise<void>;
+  /** Semantic similarity search. Returns top-N hits ranked by the
+   *  adapter's scoring function. */
+  similar(
+    query: string,
+    opts?: { limit?: number; minScore?: number },
+  ): Promise<SimilarityHit[]>;
+  /** Optional bulk-rebuild hook for vault.bulk-pull. Hosts that want
+   *  delta-only updates can implement this; others can rebuild from
+   *  scratch via their own CLI. */
+  notifyChange?(event: VaultEvent): Promise<void> | void;
+}

--- a/src/server/event-adapter.ts
+++ b/src/server/event-adapter.ts
@@ -1,0 +1,128 @@
+// EventAdapter contract — emit vault-mutation events for downstream consumers.
+//
+// Hosts that maintain derived state (Postgres search index, comment refcount,
+// audit log, embedding refresh) register an implementation; sync coordinator
+// calls into it after every successful mutation. Default is no-op so existing
+// hosts don't break.
+//
+// All event kinds carry the post-mutation `commitSha` + the resolved
+// `CodexUser` who triggered the change. Note-scoped events carry the stable
+// frontmatter UUID — that's the safe key for DB-backed features (survives
+// renames).
+
+import type { CodexUser } from './auth-adapter';
+
+export type VaultEvent =
+  | {
+      kind: 'note.saved';
+      uuid: string;
+      path: string;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'note.created';
+      uuid: string;
+      path: string;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'note.renamed';
+      uuid: string | undefined;
+      oldPath: string;
+      newPath: string;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'note.moved';
+      uuid: string | undefined;
+      oldPath: string;
+      newPath: string;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'note.deleted';
+      uuid: string | undefined;
+      path: string;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'note.reverted';
+      uuid: string | undefined;
+      path: string;
+      commitSha: string;
+      toSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'folder.created';
+      path: string;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'folder.renamed';
+      oldPath: string;
+      newPath: string;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'folder.deleted';
+      path: string;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'attachment.uploaded';
+      path: string;
+      size: number;
+      commitSha: string;
+      author: CodexUser;
+    }
+  | {
+      kind: 'vault.bulk-pull';
+      /** Commit SHAs pulled in this batch (HEAD-first). */
+      commitShas: string[];
+      /** Vault-relative paths that changed in those commits. */
+      changedPaths: string[];
+    }
+  | {
+      kind: 'vault.find-replace-applied';
+      commitSha: string;
+      changedPaths: string[];
+      totalReplacements: number;
+      author: CodexUser;
+    }
+  | {
+      kind: 'vault.tag-renamed';
+      oldTag: string;
+      newTag: string;
+      commitSha: string;
+      changedPaths: string[];
+      author: CodexUser;
+    }
+  | {
+      kind: 'vault.tag-deleted';
+      tag: string;
+      commitSha: string;
+      changedPaths: string[];
+      author: CodexUser;
+    };
+
+export interface EventAdapter {
+  /** Receive a vault event. May be sync or async; sync coordinator awaits
+   *  the promise before returning so hosts can keep their derived state
+   *  consistent with the commit. If the host's emit() throws, the commit
+   *  is NOT rolled back (it's already on disk + in git history) — the
+   *  host is expected to retry / log / dead-letter on its own.
+   */
+  emit(event: VaultEvent): Promise<void> | void;
+}
+
+/** No-op adapter used when no host adapter is registered. */
+export const noopEventAdapter: EventAdapter = { emit: () => undefined };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -41,6 +41,10 @@ export * from './user-prefs';
 export * from './config';
 export * from './uuid';
 export * from './commit-format';
+export * from './event-adapter';
+export * from './search-adapter';
+export * from './embeddings-adapter';
+export * from './annotation-adapter';
 export {
   getFileHistory,
   readFileAtSha,

--- a/src/server/search-adapter.ts
+++ b/src/server/search-adapter.ts
@@ -1,0 +1,58 @@
+// SearchAdapter contract — let hosts plug their own search backend
+// (Postgres tsvector, MeiliSearch, Algolia, semantic via embeddings, …).
+//
+// The default in-memory implementation lives in `search.ts` and handles
+// substring + tag matching. Hosts register a SearchAdapter on the GraphQL
+// context (`context.codexSearch`); when present, the search resolver
+// delegates to it instead of the in-memory default.
+//
+// The adapter contract intentionally mirrors the existing in-memory return
+// shape so swapping backends is a no-op for consumers.
+
+import type { NoteMeta } from './vault-index';
+import type { VaultEvent } from './event-adapter';
+
+export type SearchMode = 'substring' | 'fulltext' | 'semantic' | 'hybrid';
+
+// Note: in-memory `SearchHit` from `search.ts` is the established public
+// type for the default adapter's return shape. Adapter authors can return
+// values of that exact shape or use the wider AdapterSearchHit (which adds
+// 'alias' + 'semantic' match kinds — the in-memory impl doesn't produce
+// them today but external adapters might). The interface declares the
+// wider type so future-built-in adapters don't have to widen later.
+
+export interface AdapterSearchQuery {
+  q: string;
+  limit?: number;
+  /** Restrict to notes whose path starts with this prefix. */
+  folder?: string;
+  /** Restrict to notes carrying any of these tags. */
+  tags?: string[];
+  /** Restrict to notes with this status. */
+  status?: string;
+  /** Ranking strategy. Adapters may not support every mode; fall back
+   *  silently to their best effort and never throw. */
+  mode?: SearchMode;
+}
+
+export interface AdapterSearchHit {
+  meta: NoteMeta;
+  /** Where the match was found. 'semantic' for embedding-similarity hits;
+   *  'alias' when the match came from a frontmatter `aliases` entry. */
+  matchedOn: 'title' | 'body' | 'tag' | 'alias' | 'path' | 'semantic';
+  /** Body excerpt around the match, with the matched span highlighted
+   *  (e.g. <mark>...</mark>). Optional — adapters may omit. */
+  excerpt?: string;
+  /** Backend-dependent score, higher = more relevant. Treat as
+   *  opaque-but-orderable. */
+  score: number;
+}
+
+export interface SearchAdapter {
+  search(query: AdapterSearchQuery): Promise<AdapterSearchHit[]>;
+  /** Notify the adapter that the vault changed so it can refresh its
+   *  external index. Optional — only used by adapters that maintain
+   *  out-of-process state (Postgres rows, MeiliSearch docs, ...).
+   *  Wire this to the EventAdapter on the host side. */
+  notifyChange?(event: VaultEvent): Promise<void> | void;
+}

--- a/src/server/sync.ts
+++ b/src/server/sync.ts
@@ -43,6 +43,8 @@ import {
 } from './config';
 import { parseNote, serializeNote, type Frontmatter } from './frontmatter';
 import { generateUuidV7, isValidUuid } from './uuid';
+import type { EventAdapter } from './event-adapter';
+import type { CodexUser } from './auth-adapter';
 
 /**
  * Ensure the content carries a frontmatter `uuid:` field. If absent, inject
@@ -86,6 +88,14 @@ export interface SaveOptions {
   author: { name: string; email: string };
   /** Commit message — caller supplies (e.g. "Edit NexaDeck.md via admin panel"). */
   commitMessage: string;
+  /** Optional event adapter — receives a `note.saved` or `note.created`
+   *  event after a successful commit. Hosts use this to drive search-
+   *  index updates, audit log, etc. without polling. */
+  events?: EventAdapter;
+  /** The CodexUser who triggered the save. Used as the `author` field in
+   *  emitted events. When omitted, the event's `author.email` is derived
+   *  from `opts.author.email` (less expressive but functional). */
+  user?: CodexUser;
 }
 
 // Single mutex for all vault writes. Implemented as a promise chain.
@@ -181,8 +191,30 @@ export async function saveNote(opts: SaveOptions): Promise<SaveOutcome> {
     invalidatePageRank();
     schedulePush();
 
+    // Emit AFTER index invalidation so any listener that pulls the freshly-
+    // saved meta sees the committed state. Re-parse the final content for
+    // the uuid (cheap — it's the file we just wrote).
+    const { uuid: writtenUuid } = ensureNoteUuid(finalContent);
+    const eventKind: 'note.saved' | 'note.created' = exists ? 'note.saved' : 'note.created';
+    await opts.events?.emit({
+      kind: eventKind,
+      uuid: writtenUuid,
+      path: opts.path,
+      commitSha: commit.sha,
+      author: opts.user ?? authorAsCodexUser(opts.author),
+    });
+
     return { kind: 'OK', newSha, commitSha: commit.sha };
   });
+}
+
+/** Map a `{ name, email }` git-author pair back to a minimal CodexUser
+ *  shape — used when callers don't pass a separate `user` field on the
+ *  options. The id falls back to the email so downstream consumers can
+ *  still key on something stable; hosts that want per-user analytics
+ *  should pass the real `user`. */
+function authorAsCodexUser(author: { name: string; email: string }): CodexUser {
+  return { id: author.email, name: author.name, email: author.email };
 }
 
 // ─── UUID backfill ────────────────────────────────────────────────────────
@@ -308,6 +340,8 @@ export interface RenameOptions {
   newPath: string;
   author: { name: string; email: string };
   commitMessage: string;
+  events?: EventAdapter;
+  user?: CodexUser;
 }
 
 function normalizedFormsOfPath(p: string): {
@@ -404,6 +438,7 @@ export async function renameNote(opts: RenameOptions): Promise<RenameOutcome> {
     // and pre-compute the rewritten content. Done BEFORE the rename so the
     // index is still keyed on oldPath.
     const idx = await getIndex();
+    const renamedUuid = idx.files.get(oldPath)?.uuid;
     const rewrites: Array<{ path: string; content: string }> = [];
     for (const [notePath, meta] of idx.files) {
       if (notePath === oldPath) continue;
@@ -444,6 +479,15 @@ export async function renameNote(opts: RenameOptions): Promise<RenameOutcome> {
     invalidatePageRank();
     schedulePush();
 
+    await opts.events?.emit({
+      kind: 'note.renamed',
+      uuid: renamedUuid,
+      oldPath,
+      newPath,
+      commitSha: commit.sha,
+      author: opts.user ?? authorAsCodexUser(opts.author),
+    });
+
     return {
       kind: 'OK',
       newPath,
@@ -465,6 +509,8 @@ export interface DeleteOptions {
   path: string;
   author: { name: string; email: string };
   commitMessage: string;
+  events?: EventAdapter;
+  user?: CodexUser;
 }
 
 /**
@@ -506,6 +552,7 @@ export async function deleteNote(opts: DeleteOptions): Promise<DeleteOutcome> {
     // (wikilinks that resolve to nothing). Use the in-memory index BEFORE
     // the delete so the link table is still keyed correctly.
     const idx = await getIndex();
+    const deletedUuid = idx.files.get(rel)?.uuid;
     const orphanedFiles: string[] = [];
     for (const [notePath, meta] of idx.files) {
       if (notePath === rel) continue;
@@ -529,6 +576,14 @@ export async function deleteNote(opts: DeleteOptions): Promise<DeleteOutcome> {
     invalidateIndex();
     invalidatePageRank();
     schedulePush();
+
+    await opts.events?.emit({
+      kind: 'note.deleted',
+      uuid: deletedUuid,
+      path: rel,
+      commitSha: commit.sha,
+      author: opts.user ?? authorAsCodexUser(opts.author),
+    });
 
     return {
       kind: 'OK',


### PR DESCRIPTION
## Summary

Four foundation adapter contracts for the v1 work (chriscase/AbydosTemple#106). Hosts plug their own implementations via the GraphQL context; Ostracon library code never imports a specific backend.

| Contract | Status | Registration | Closes |
|---|---|---|---|
| EventAdapter | typed + wired (saveNote/renameNote/deleteNote) | \`context.codexEvents\` | #16 |
| SearchAdapter | typed | \`context.codexSearch\` | #19 |
| EmbeddingsAdapter | typed | \`context.codexEmbeddings\` | #20 |
| AnnotationAdapter | typed | \`context.codexAnnotations\` | #23 |

## EventAdapter — what fires today

After a successful commit, the sync coordinator emits:

- \`saveNote\` → \`note.created\` (new file) or \`note.saved\` (existing) with uuid + path + commitSha + author
- \`renameNote\` → \`note.renamed\` with original uuid + oldPath + newPath
- \`deleteNote\` → \`note.deleted\` with original uuid + path

The full event union covers folder ops, attachment uploads, reverts, find-replace, tag mutations, and \`vault.bulk-pull\` (webhook git-pull surface). Those event KINDS are typed and ready; the actual emit calls in the corresponding mutations will land incrementally as host consumers need them.

## SearchAdapter / EmbeddingsAdapter / AnnotationAdapter — contracts only

Just the interfaces + types + registration seam. The resolver-side wiring (\"if context.codexSearch is set, delegate to it; else fall through to the in-memory default\") lands with each first host impl:

- HoR Postgres tsvector → wires SearchAdapter
- HoR pgvector → wires EmbeddingsAdapter
- HoR threaded comments → wires AnnotationAdapter

This split keeps each PR focused.

## Naming note

The existing public type \`SearchHit\` from \`search.ts\` (in-memory impl shape) is preserved. The new adapter types use \`AdapterSearchQuery\` / \`AdapterSearchHit\` to avoid name conflicts. The adapter type has a wider \`matchedOn\` union (\`'alias'\` + \`'semantic'\` added) so future built-in adapters don't have to widen later.

## Test plan

- [x] \`npm run type-check\` clean
- [x] 237 / 237 vitest pass (6 new EventAdapter integration tests + 231 prior)
- [x] EventAdapter tests cover note.created / note.saved / note.renamed / note.deleted, including UUID preservation through rename/delete, plus CONFLICT-doesn't-emit, plus opts.events-omitted-is-safe

Closes #16, #19, #20, #23.