### PR TITLE
ux(history): author chip + Why? input on edit/create

### DIFF
--- a/src/ui/CodexEditor.tsx
+++ b/src/ui/CodexEditor.tsx
@@ -64,8 +64,8 @@ const MDEditor = dynamic(
 );
 
 const SAVE_NOTE = `
-  mutation SaveNote($path: String!, $content: String!, $baseSha: String!, $commitMessage: String) {
-    saveNote(path: $path, content: $content, baseSha: $baseSha, commitMessage: $commitMessage) {
+  mutation SaveNote($path: String!, $content: String!, $baseSha: String!, $userMessage: String) {
+    saveNote(path: $path, content: $content, baseSha: $baseSha, userMessage: $userMessage) {
       kind
       newSha
       commitSha
@@ -82,8 +82,8 @@ const SAVE_NOTE = `
 `;
 
 const CREATE_NOTE = `
-  mutation CreateNote($path: String!, $content: String!, $commitMessage: String) {
-    createNote(path: $path, content: $content, commitMessage: $commitMessage) {
+  mutation CreateNote($path: String!, $content: String!, $userMessage: String) {
+    createNote(path: $path, content: $content, userMessage: $userMessage) {
       kind
       newSha
       commitSha
@@ -144,7 +144,7 @@ export default function CodexEditor({
   const initialParsed = useMemo(() => parseNote(initialContent), [initialContent]);
   const [frontmatter, setFrontmatter] = useState<Frontmatter>(initialParsed.data);
   const [body, setBody] = useState<string>(initialParsed.content);
-  const [commitMessage, setCommitMessage] = useState<string>('');
+  const [userMessage, setUserMessage] = useState<string>('');
   const [toast, setToast] = useState<ToastState>({ kind: 'idle' });
   const [frontmatterCollapsed, setFrontmatterCollapsed] = useState<boolean>(false);
   // currentBaseSha tracks the latest SHA the server has confirmed — bumped after
@@ -162,7 +162,7 @@ export default function CodexEditor({
     setFrontmatter(initialParsed.data);
     setBody(initialParsed.content);
     setCurrentBaseSha(baseSha);
-    setCommitMessage('');
+    setUserMessage('');
     setToast({ kind: 'idle' });
     setFrontmatterCollapsed(false);
   }, [path, initialParsed, baseSha]);
@@ -188,7 +188,7 @@ export default function CodexEditor({
       const variables: Record<string, unknown> = {
         path,
         content,
-        commitMessage: commitMessage.trim() || undefined,
+        userMessage: userMessage.trim() || undefined,
       };
       if (!isCreate) variables.baseSha = currentBaseSha;
 
@@ -397,9 +397,10 @@ export default function CodexEditor({
       <input
         type="text"
         className={styles.editorCommitMessage}
-        placeholder={`Commit message (default: "Edit ${path} via admin panel")`}
-        value={commitMessage}
-        onChange={(e) => setCommitMessage(e.target.value)}
+        placeholder="Why? (optional — adds a note to this commit)"
+        value={userMessage}
+        onChange={(e) => setUserMessage(e.target.value)}
+        aria-label="Optional commit reason"
       />
 
       <FrontmatterForm

--- a/src/ui/HistoryPanel.tsx
+++ b/src/ui/HistoryPanel.tsx
@@ -218,20 +218,21 @@ export default function HistoryPanel({
                 className={`${styles.historyItem} ${isActive ? styles.historyItemActive : ''}`}
                 onClick={() => setActiveSha(entry.sha)}
               >
-                <div>
-                  <strong>{entry.message.split('\n')[0]}</strong>
+                <div className={styles.historyItemHeader}>
+                  <AuthorChip
+                    name={entry.authorName}
+                    email={entry.authorEmail}
+                    title={`${entry.authorName} <${entry.authorEmail}>`}
+                  />
+                  <strong className={styles.historyItemSubject}>
+                    {entry.message.split('\n')[0]}
+                  </strong>
                   {isHead && (
-                    <span
-                      className={styles.frontmatterCollapsedBadge}
-                      style={{ marginLeft: '0.5rem' }}
-                    >
-                      current
-                    </span>
+                    <span className={styles.historyCurrentBadge}>current</span>
                   )}
                 </div>
                 <div className={styles.historyMeta}>
                   <span className={styles.historyShortSha}>{entry.shortSha}</span>
-                  <span>{entry.authorName}</span>
                   <span>{formatDate(entry.date)}</span>
                 </div>
               </li>
@@ -243,7 +244,12 @@ export default function HistoryPanel({
       {active && (
         <div>
           <div className={styles.historyHeader} style={{ marginTop: '0.75rem' }}>
-            <div>
+            <div className={styles.historyActiveHeader}>
+              <AuthorChip
+                name={active.authorName}
+                email={active.authorEmail}
+                title={`${active.authorName} <${active.authorEmail}>`}
+              />
               <strong>{active.shortSha}</strong>
               <span className={styles.historyMeta} style={{ display: 'inline', marginLeft: '0.5rem' }}>
                 {active.authorName} · {formatDate(active.date)}
@@ -270,4 +276,50 @@ export default function HistoryPanel({
       )}
     </div>
   );
+}
+
+/** Visual chip with the committer's initials in a colored disc + their
+ *  display name. Disc color is stable per email so the same author always
+ *  shows the same hue in the History list. */
+function AuthorChip({
+  name,
+  email,
+  title,
+}: {
+  name: string;
+  email: string;
+  title?: string;
+}) {
+  const initials = authorInitials(name, email);
+  const hue = stableHueFromString(email || name);
+  return (
+    <span className={styles.authorChip} title={title}>
+      <span
+        className={styles.authorChipAvatar}
+        style={{
+          background: `hsl(${hue} 65% 32%)`,
+          color: `hsl(${hue} 80% 92%)`,
+        }}
+        aria-hidden="true"
+      >
+        {initials}
+      </span>
+      <span className={styles.authorChipName}>{name}</span>
+    </span>
+  );
+}
+
+function authorInitials(name: string, email: string): string {
+  const source = (name || email.split('@')[0] || '?').trim();
+  const parts = source.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+  return source.slice(0, 2).toUpperCase();
+}
+
+function stableHueFromString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h % 360;
 }

--- a/src/ui/codex.module.css
+++ b/src/ui/codex.module.css
@@ -1689,10 +1689,81 @@
 
 .historyItem {
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
   font-size: 0.85rem;
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  transition: background-color 100ms ease, border-color 100ms ease;
+}
+
+.historyItem:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.historyItemHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.historyItemSubject {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.historyCurrentBadge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(120, 200, 255, 0.18);
+  color: rgb(180, 220, 255);
+  border: 1px solid rgba(120, 200, 255, 0.4);
+}
+
+.historyActiveHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+/* Author chip — avatar disc with initials + display name. Color is
+   deterministic from the author's email so the same person always shows
+   the same hue in the history list. */
+.authorChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.authorChipAvatar {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  flex: 0 0 auto;
+}
+
+.authorChipName {
+  color: var(--text-secondary);
+  font-weight: 500;
 }
 
 .historyItemActive {


### PR DESCRIPTION
## Summary

Two small UI polish wins on the multi-user surfaces. Completes the user-facing half of chriscase/AbydosTemple#108.

### CodexEditor: \"Why?\" input

The legacy *Commit message* override input becomes *Why? (optional — adds a note to this commit)*. It now sends the new \`userMessage\` GraphQL arg instead of overriding the whole commit message — so the server still builds the standardized subject + trailers and just appends the user's free-text reason as the body. UX-aligned with the structured format we just shipped.

### HistoryPanel: AuthorChip

Each commit row gets an AuthorChip — avatar disc with initials + display name — before the subject. Disc color is deterministic from the author's email so the same person always shows the same hue when scanning a multi-user history. Same chip appears in the active-commit header above the diff.

## Test plan

- [x] type-check clean
- [x] 237/237 tests pass (no behavior change in non-UI paths)
- [ ] Smoke after merge + HoR ostracon refresh: edit a note, type something in the Why field, save → confirm the commit body carries that text + the trailers are intact. History panel shows the author chip with cc@chriscase.cc's initials.