### PR TITLE
feat(search): vaultSearch delegates to context.codexSearch when set

### DIFF
--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -38,6 +38,7 @@ import {
   CodexNoteSummaryType,
   CodexGraphType,
   CodexSearchHitType,
+  CodexSearchModeEnum,
   CodexHistoryEntryType,
   CodexPreviewResultType,
   CodexTagSummaryType,
@@ -164,18 +165,66 @@ export const codexQueryFields: Record<
 
   vaultSearch: {
     type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(CodexSearchHitType))),
-    description: 'Substring + tag search across the vault index.',
+    description:
+      'Search the vault. When the host has registered a SearchAdapter on context.codexSearch (e.g. a Postgres tsvector or pgvector backend), the resolver delegates to it; otherwise falls through to the in-memory default (substring + tag match).',
     args: {
       query: { type: new GraphQLNonNull(GraphQLString) },
       limit: { type: GraphQLInt },
+      /** Restrict to notes whose path starts with this prefix. Host
+       *  adapters honor this; the in-memory default ignores it. */
+      folder: { type: GraphQLString },
+      /** Restrict to notes carrying any of these tags. Host adapters
+       *  honor this; the in-memory default ignores it. */
+      tags: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+      /** Restrict to notes with this status frontmatter value. */
+      status: { type: GraphQLString },
+      /** Search mode: substring / fulltext / semantic / hybrid. The
+       *  in-memory default treats anything but 'substring' as substring.
+       *  Hosts pick the best fit per mode. */
+      mode: { type: CodexSearchModeEnum },
     },
     resolve: async (_parent, args, context) => {
       await requireCodexPermission(context, 'codex.read');
-      const hits = await searchVault(args.query as string, (args.limit as number | undefined) ?? 20);
+      const query = args.query as string;
+      const limit = (args.limit as number | undefined) ?? 20;
+      const folder = args.folder as string | undefined;
+      const tags = args.tags as string[] | undefined;
+      const status = args.status as string | undefined;
+      const mode = args.mode as
+        | 'substring'
+        | 'fulltext'
+        | 'semantic'
+        | 'hybrid'
+        | undefined;
+
+      // When the host has registered a SearchAdapter, delegate. The
+      // adapter handles ranking, mode selection, and filter semantics.
+      if (context.codexSearch) {
+        const hits = await context.codexSearch.search({
+          q: query,
+          limit,
+          folder,
+          tags,
+          status,
+          mode,
+        });
+        return hits.map((h) => ({
+          note: summarize(h.meta),
+          score: h.score,
+          matchedOn: h.matchedOn,
+          excerpt: h.excerpt,
+        }));
+      }
+
+      // No adapter — fall back to the in-memory default. It only
+      // implements substring + tag match; folder/tags/status/mode args
+      // are silently ignored.
+      const hits = await searchVault(query, limit);
       return hits.map((h) => ({
         note: summarize(h.meta),
         score: h.score,
         matchedOn: h.matchedOn,
+        excerpt: h.excerpt,
       }));
     },
   },

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -133,6 +133,23 @@ export const CodexSearchHitMatchEnum = new GraphQLEnumType({
     tag: { value: 'tag' },
     path: { value: 'path' },
     body: { value: 'body' },
+    /** Frontmatter alias matched (host adapters that index aliases). */
+    alias: { value: 'alias' },
+    /** Embedding-similarity hit (semantic search mode). */
+    semantic: { value: 'semantic' },
+  },
+});
+
+/** Search mode the resolver passes through to the host adapter. The
+ *  in-memory default ignores anything other than 'substring' and treats
+ *  unknown modes as substring. */
+export const CodexSearchModeEnum = new GraphQLEnumType({
+  name: 'CodexSearchMode',
+  values: {
+    substring: { value: 'substring' },
+    fulltext: { value: 'fulltext' },
+    semantic: { value: 'semantic' },
+    hybrid: { value: 'hybrid' },
   },
 });
 


### PR DESCRIPTION
## Summary

Connects the SearchAdapter seam wired in #30. \`vaultSearch\` now checks \`context.codexSearch\` and delegates if set; falls through to the in-memory default otherwise.

## Changes

- New optional args on \`vaultSearch\`: \`folder\`, \`tags\`, \`status\`, \`mode\`. Forwarded to the adapter. The in-memory default ignores them.
- \`CodexSearchHitMatchEnum\` gains \`alias\` and \`semantic\` values.
- New \`CodexSearchModeEnum\` (substring / fulltext / semantic / hybrid).
- \`CodexSearchHit\` returns adapter-supplied excerpts.

Default behavior unchanged for any host that hasn't registered \`context.codexSearch\` — every existing call still hits the same in-memory implementation.

## Unblocks

chriscase/AbydosTemple#111 — HoR Postgres tsvector adapter (next PR).

## Test plan

- [x] type-check clean
- [x] 237/237 vitest pass