### PR TITLE
fix(search): score is Float, not Int

### DIFF
--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -157,7 +157,10 @@ export const CodexSearchHitType: GraphQLObjectType = new GraphQLObjectType({
   name: 'CodexSearchHit',
   fields: () => ({
     note: { type: new GraphQLNonNull(CodexNoteSummaryType) },
-    score: { type: new GraphQLNonNull(GraphQLInt) },
+    // Float (not Int) so adapters returning continuous ranks — tsvector
+    // ts_rank_cd, cosine similarity from pgvector, etc. — can pass them
+    // through without rounding.
+    score: { type: new GraphQLNonNull(GraphQLFloat) },
     matchedOn: { type: new GraphQLNonNull(CodexSearchHitMatchEnum) },
     excerpt: { type: GraphQLString },
   }),


### PR DESCRIPTION
tsvector ts_rank_cd and cosine similarity scores are continuous; the GraphQL Int field rejected them with `Int cannot represent non-integer value: 21.4`. Switch to Float.