### PR TITLE
feat(search): Cmd-K vault search palette (#21)

### DIFF
--- a/src/ui/SearchPalette.tsx
+++ b/src/ui/SearchPalette.tsx
@@ -1,0 +1,486 @@
+'use client';
+
+// Cmd-K / Ctrl-K search palette.
+//
+// Centered overlay on desktop (>= 640px), full-height bottom sheet on
+// mobile. Queries vaultSearch with mode='fulltext' so the host's tsvector
+// (or any SearchAdapter implementation) returns ranked hits with
+// highlighted excerpts. Keyboard-first: arrows + Enter, Esc to dismiss.
+//
+// Open it via the exported `<SearchPaletteTrigger />` button or by
+// dispatching the `ostracon:open-search-palette` custom event. The
+// palette itself listens for Cmd-K / Ctrl-K globally; consuming hosts
+// can ignore the hotkey if they wire conflicting bindings.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useCodexGraphqlRequest, useCodexNavigation } from './CodexAdapters';
+import styles from './codex.module.css';
+
+// ─── GraphQL query ──────────────────────────────────────────────────────────
+
+const PALETTE_SEARCH_QUERY = `
+  query VaultSearchPalette(
+    $query: String!
+    $limit: Int
+    $mode: CodexSearchMode
+    $folder: String
+    $tags: [String!]
+  ) {
+    vaultSearch(query: $query, limit: $limit, mode: $mode, folder: $folder, tags: $tags) {
+      score
+      matchedOn
+      excerpt
+      note {
+        path
+        title
+        folder
+        status
+        isAutoManaged
+      }
+    }
+  }
+`;
+
+interface Hit {
+  score: number;
+  matchedOn: 'title' | 'tag' | 'path' | 'body' | 'alias' | 'semantic';
+  excerpt?: string | null;
+  note: {
+    path: string;
+    title: string;
+    folder: string;
+    status?: string | null;
+    isAutoManaged: boolean;
+  };
+}
+
+type Mode = 'hybrid' | 'fulltext' | 'substring' | 'tags';
+
+const MODES: Array<{ id: Mode; label: string; hint: string }> = [
+  { id: 'hybrid', label: 'Hybrid', hint: 'Ranked across signals' },
+  { id: 'fulltext', label: 'Full-text', hint: 'tsvector ranking' },
+  { id: 'substring', label: 'Substring', hint: 'Plain ILIKE / contains' },
+  { id: 'tags', label: 'Tags', hint: 'Match notes carrying a tag' },
+];
+
+// Map UI mode to the server's CodexSearchMode arg. 'tags' is a UI-level
+// shortcut: we pass the query into the `tags` filter and use the
+// substring mode on top of that filter.
+function serverModeFor(mode: Mode): { mode: string; useTagsFilter: boolean } {
+  switch (mode) {
+    case 'tags':
+      return { mode: 'substring', useTagsFilter: true };
+    default:
+      return { mode, useTagsFilter: false };
+  }
+}
+
+const DEBOUNCE_MS = 200;
+const RECENT_KEY = 'ostracon-search-palette-recent';
+const RECENT_CAP = 6;
+
+function loadRecents(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(RECENT_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s): s is string => typeof s === 'string').slice(0, RECENT_CAP);
+  } catch {
+    return [];
+  }
+}
+
+function saveRecent(query: string) {
+  if (typeof window === 'undefined') return;
+  if (!query.trim()) return;
+  const list = loadRecents().filter((s) => s !== query);
+  list.unshift(query);
+  try {
+    window.localStorage.setItem(RECENT_KEY, JSON.stringify(list.slice(0, RECENT_CAP)));
+  } catch {
+    /* quota / private-mode — ignore */
+  }
+}
+
+// ─── Trigger button + hotkey ─────────────────────────────────────────────────
+
+const OPEN_EVENT = 'ostracon:open-search-palette';
+
+/** Dispatch from anywhere in the host app to open the palette. The
+ *  palette listens for this event globally. */
+export function openSearchPalette() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(OPEN_EVENT));
+}
+
+/** Small button hosts can drop into their chrome to surface the palette
+ *  on touch. The hotkey works regardless. */
+export function SearchPaletteTrigger({ className }: { className?: string }) {
+  return (
+    <button
+      type="button"
+      className={className ?? styles.paletteTriggerButton}
+      onClick={() => openSearchPalette()}
+      aria-label="Search the vault"
+      title="Search"
+    >
+      <span className={styles.paletteTriggerIcon} aria-hidden="true">⌕</span>
+      <span className={styles.paletteTriggerLabel}>Search</span>
+    </button>
+  );
+}
+
+// ─── Palette ─────────────────────────────────────────────────────────────────
+
+export interface SearchPaletteProps {
+  /** Render path for hit results. Defaults to `/admin/codex/note/<path>` —
+   *  override if the host mounts codex routes elsewhere. */
+  noteHref?: (path: string) => string;
+}
+
+export function SearchPalette({ noteHref }: SearchPaletteProps) {
+  const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [query, setQuery] = useState('');
+  const [mode, setMode] = useState<Mode>('hybrid');
+  const [hits, setHits] = useState<Hit[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [recents, setRecents] = useState<string[]>([]);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const graphqlRequest = useCodexGraphqlRequest();
+  const { useRouter } = useCodexNavigation();
+  const router = useRouter();
+
+  const hrefFor = useMemo(
+    () =>
+      noteHref ??
+      ((p: string) =>
+        '/admin/codex/note/' +
+        p
+          .replace(/\.md$/i, '')
+          .split(/[\\/]/g)
+          .map((seg) => encodeURIComponent(seg))
+          .join('/')),
+    [noteHref],
+  );
+
+  // Mount portal once (avoid SSR mismatch).
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Refresh recents when palette opens.
+  useEffect(() => {
+    if (open) setRecents(loadRecents());
+  }, [open]);
+
+  // Open via custom event from anywhere in the host app. Hosts wire
+  // their own hotkey (e.g. Cmd-Shift-K) by calling `openSearchPalette()`.
+  // Internal binding is intentionally absent so the host's existing
+  // command-palette / quick-open hotkeys don't fight ours.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onOpenEvt = () => setOpen(true);
+    window.addEventListener(OPEN_EVENT, onOpenEvt);
+    return () => window.removeEventListener(OPEN_EVENT, onOpenEvt);
+  }, []);
+
+  // Auto-focus input when opening.
+  useEffect(() => {
+    if (open) {
+      const t = setTimeout(() => inputRef.current?.focus(), 30);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  // Lock body scroll while open + restore on close.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (open) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+  }, [open]);
+
+  // Debounced search.
+  useEffect(() => {
+    if (!open) return;
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setHits(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      try {
+        const { mode: serverMode, useTagsFilter } = serverModeFor(mode);
+        const { data, errors } = await graphqlRequest<{ vaultSearch: Hit[] }>(
+          PALETTE_SEARCH_QUERY,
+          {
+            query: useTagsFilter ? '' : trimmed,
+            limit: 24,
+            mode: serverMode,
+            tags: useTagsFilter ? [trimmed] : undefined,
+          },
+        );
+        if (cancelled) return;
+        if (errors?.length) {
+          console.warn('[search-palette] errors', errors);
+          setHits([]);
+        } else {
+          setHits(data?.vaultSearch ?? []);
+        }
+        setActiveIdx(0);
+      } catch (err) {
+        console.warn('[search-palette] failed', err);
+        if (!cancelled) setHits([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [open, query, mode, graphqlRequest]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setActiveIdx(0);
+  }, []);
+
+  const openHit = useCallback(
+    (hit: Hit) => {
+      saveRecent(query.trim());
+      close();
+      router.push(hrefFor(hit.note.path));
+    },
+    [close, hrefFor, query, router],
+  );
+
+  // Keyboard navigation across results.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        return;
+      }
+      const list = hits ?? [];
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIdx((i) => Math.min(i + 1, Math.max(0, list.length - 1)));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIdx((i) => Math.max(0, i - 1));
+      } else if (e.key === 'Enter') {
+        if (list.length > 0 && activeIdx >= 0 && activeIdx < list.length) {
+          e.preventDefault();
+          openHit(list[activeIdx]);
+        }
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, hits, activeIdx, close, openHit]);
+
+  // Scroll the active row into view on arrow nav.
+  useEffect(() => {
+    if (!listRef.current) return;
+    const el = listRef.current.querySelector<HTMLElement>(
+      `[data-palette-hit-idx="${activeIdx}"]`,
+    );
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeIdx]);
+
+  if (!mounted || !open) return null;
+
+  const list = hits ?? [];
+  const hasQuery = query.trim().length > 0;
+
+  return createPortal(
+    <div
+      className={styles.paletteBackdrop}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search vault"
+    >
+      <div className={styles.paletteSheet}>
+        <div className={styles.paletteHandle} aria-hidden="true" />
+        <div className={styles.paletteSearchRow}>
+          <span className={styles.paletteSearchIcon} aria-hidden="true">⌕</span>
+          <input
+            ref={inputRef}
+            type="search"
+            className={styles.paletteInput}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search the vault…"
+            aria-label="Search the vault"
+            autoComplete="off"
+            spellCheck={false}
+            // Don't let the browser's password-manager / autofill UI overlay
+            // the palette on mobile.
+            data-1p-ignore
+            data-lpignore="true"
+          />
+          {query && (
+            <button
+              type="button"
+              className={styles.paletteClearButton}
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear query"
+              title="Clear"
+            >
+              ✕
+            </button>
+          )}
+          <button
+            type="button"
+            className={styles.paletteCloseButton}
+            onClick={close}
+            aria-label="Close search"
+          >
+            Esc
+          </button>
+        </div>
+
+        <div className={styles.paletteModeRow} role="tablist" aria-label="Search mode">
+          {MODES.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              role="tab"
+              aria-selected={mode === m.id}
+              className={
+                mode === m.id
+                  ? styles.paletteModeChipActive
+                  : styles.paletteModeChip
+              }
+              onClick={() => setMode(m.id)}
+              title={m.hint}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.paletteResults} aria-live="polite">
+          {!hasQuery && recents.length > 0 && (
+            <section className={styles.paletteSection}>
+              <h4 className={styles.paletteSectionHeading}>Recent searches</h4>
+              <ul className={styles.paletteRecentList}>
+                {recents.map((r) => (
+                  <li key={r}>
+                    <button
+                      type="button"
+                      className={styles.paletteRecentChip}
+                      onClick={() => {
+                        setQuery(r);
+                        inputRef.current?.focus();
+                      }}
+                    >
+                      {r}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {!hasQuery && recents.length === 0 && (
+            <div className={styles.paletteEmpty}>
+              <p>Type to search the vault.</p>
+              <p className={styles.paletteHint}>
+                Tip: switch to <kbd>Full-text</kbd> for ranked tsvector hits with
+                highlighted excerpts.
+              </p>
+            </div>
+          )}
+
+          {hasQuery && loading && list.length === 0 && (
+            <ul className={styles.paletteResultList} aria-busy="true">
+              {[0, 1, 2, 3].map((i) => (
+                <li key={i} className={styles.paletteSkeleton}>
+                  <span className={styles.paletteSkeletonTitle} />
+                  <span className={styles.paletteSkeletonExcerpt} />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {hasQuery && !loading && list.length === 0 && (
+            <div className={styles.paletteEmpty}>
+              <p>No matches for &ldquo;{query}&rdquo;.</p>
+              <p className={styles.paletteHint}>
+                Try a different word, or switch to <kbd>Tags</kbd> mode if you're
+                searching by tag.
+              </p>
+            </div>
+          )}
+
+          {hasQuery && list.length > 0 && (
+            <ul ref={listRef} className={styles.paletteResultList}>
+              {list.map((hit, idx) => (
+                <li
+                  key={hit.note.path}
+                  data-palette-hit-idx={idx}
+                  className={
+                    idx === activeIdx
+                      ? styles.paletteHitActive
+                      : styles.paletteHit
+                  }
+                  onMouseEnter={() => setActiveIdx(idx)}
+                  onClick={() => openHit(hit)}
+                >
+                  <div className={styles.paletteHitHeader}>
+                    <span className={styles.paletteHitTitle}>{hit.note.title}</span>
+                    <span className={styles.paletteHitFolder}>
+                      {hit.note.folder.replace(/^\d+\s*-\s*/, '')}
+                    </span>
+                    <span className={styles.paletteHitBadge}>
+                      {hit.matchedOn}
+                    </span>
+                  </div>
+                  {hit.excerpt && (
+                    <div
+                      className={styles.paletteHitExcerpt}
+                      // Server returns ts_headline output with safe <b>
+                      // wrappers around matched terms. Render as HTML so
+                      // the highlights show.
+                      dangerouslySetInnerHTML={{ __html: hit.excerpt }}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className={styles.paletteFooter} aria-hidden="true">
+          <span><kbd>↑↓</kbd> navigate</span>
+          <span><kbd>Enter</kbd> open</span>
+          <span><kbd>Esc</kbd> close</span>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/ui/codex.module.css
+++ b/src/ui/codex.module.css
@@ -2088,3 +2088,471 @@
   background: rgba(255, 255, 255, 0.04);
   color: var(--accent, rgb(120, 200, 255));
 }
+
+/* ─── Cmd-K search palette ─────────────────────────────────────────────── */
+
+/* The trigger button — small, dropped into the host's topbar. Reveals
+   itself with both a label (Search) and a ⌘K hint so users learn the
+   hotkey. On phones the kbd hint collapses. */
+.paletteTriggerButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.7rem 0.35rem 0.6rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  border-radius: 8px;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 100ms ease, border-color 100ms ease, color 100ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.paletteTriggerButton:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: var(--text-primary, white);
+}
+
+.paletteTriggerIcon {
+  font-size: 1rem;
+  line-height: 1;
+  opacity: 0.8;
+}
+
+.paletteTriggerLabel {
+  font-weight: 500;
+}
+
+.paletteTriggerKey {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  font-size: 0.7rem;
+  padding: 0.05rem 0.4rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.65));
+}
+
+@media (max-width: 480px) {
+  .paletteTriggerLabel,
+  .paletteTriggerKey {
+    display: none;
+  }
+  .paletteTriggerButton {
+    padding: 0.4rem;
+    border-radius: 999px;
+  }
+  .paletteTriggerIcon {
+    font-size: 1.1rem;
+  }
+}
+
+/* Backdrop — desktop: centered modal with dim. Mobile: bottom sheet
+   anchored to the bottom edge with the sheet sliding up from below. */
+.paletteBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 10, 16, 0.65);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(2rem, 8vh, 6rem) 1rem 1rem;
+  animation: paletteFadeIn 160ms ease-out;
+}
+
+@keyframes paletteFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.paletteSheet {
+  width: min(640px, 100%);
+  max-height: min(80vh, 720px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated, #14171f);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  box-shadow:
+    0 30px 60px -20px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+  animation: paletteRise 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes paletteRise {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Mobile bottom-sheet form factor */
+@media (max-width: 640px) {
+  .paletteBackdrop {
+    align-items: stretch;
+    padding: 0;
+  }
+  .paletteSheet {
+    width: 100%;
+    max-height: 100%;
+    margin-top: auto;
+    border-radius: 16px 16px 0 0;
+    border-bottom: none;
+    height: 92vh;
+    animation: paletteSlideUp 240ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  @keyframes paletteSlideUp {
+    from { transform: translateY(100%); }
+    to { transform: translateY(0); }
+  }
+}
+
+/* Handle bar — visual affordance for swipe-down on mobile. Hidden on
+   desktop. */
+.paletteHandle {
+  display: none;
+  width: 36px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  margin: 0.6rem auto 0.2rem;
+}
+
+@media (max-width: 640px) {
+  .paletteHandle {
+    display: block;
+  }
+}
+
+.paletteSearchRow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem 0.7rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.paletteSearchIcon {
+  font-size: 1.2rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.6));
+  flex: 0 0 auto;
+}
+
+.paletteInput {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-primary, white);
+  font-size: 1.05rem;
+  font-family: inherit;
+  padding: 0.35rem 0;
+  /* Prevent iOS Safari from zooming the page on input focus. */
+  font-size: 16px;
+}
+
+.paletteInput::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.paletteClearButton,
+.paletteCloseButton {
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary, rgba(255, 255, 255, 0.65));
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.3rem 0.55rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.paletteClearButton {
+  font-family: inherit;
+  font-size: 0.85rem;
+}
+
+.paletteClearButton:hover,
+.paletteCloseButton:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary, white);
+}
+
+.paletteModeRow {
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.55rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.paletteModeRow::-webkit-scrollbar { display: none; }
+
+.paletteModeChip,
+.paletteModeChipActive {
+  flex: 0 0 auto;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.65));
+  font-size: 0.78rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 100ms ease, border-color 100ms ease, color 100ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.paletteModeChip:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: var(--text-primary, white);
+}
+
+.paletteModeChipActive {
+  background: rgba(120, 200, 255, 0.16);
+  border-color: rgba(120, 200, 255, 0.5);
+  color: rgb(180, 220, 255);
+  font-weight: 600;
+}
+
+.paletteResults {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 0.4rem 0;
+}
+
+.paletteSection {
+  padding: 0.5rem 1rem 0.8rem;
+}
+
+.paletteSectionHeading {
+  margin: 0 0 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary, rgba(255, 255, 255, 0.45));
+}
+
+.paletteRecentList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.paletteRecentChip {
+  padding: 0.3rem 0.7rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  color: var(--text-primary, white);
+  font-size: 0.8rem;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.paletteRecentChip:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.paletteEmpty {
+  padding: 1.5rem 1rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.6));
+  font-size: 0.9rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.paletteEmpty p {
+  margin: 0 0 0.5rem;
+}
+
+.paletteEmpty p:last-child {
+  margin-bottom: 0;
+}
+
+.paletteHint {
+  color: var(--text-tertiary, rgba(255, 255, 255, 0.45));
+  font-size: 0.82rem;
+}
+
+.paletteHint kbd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  font-size: 0.72rem;
+  padding: 0.05rem 0.35rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+}
+
+.paletteResultList {
+  list-style: none;
+  margin: 0;
+  padding: 0.3rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.paletteHit,
+.paletteHitActive {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 80ms ease, border-color 80ms ease;
+  border: 1px solid transparent;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.paletteHit:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.paletteHitActive {
+  background: rgba(120, 200, 255, 0.10);
+  border-color: rgba(120, 200, 255, 0.32);
+}
+
+.paletteHitHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.paletteHitTitle {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary, white);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.paletteHitFolder {
+  font-size: 0.72rem;
+  color: var(--text-tertiary, rgba(255, 255, 255, 0.5));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  white-space: nowrap;
+}
+
+.paletteHitBadge {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text-tertiary, rgba(255, 255, 255, 0.55));
+}
+
+.paletteHitExcerpt {
+  font-size: 0.83rem;
+  line-height: 1.5;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  /* The server returns ts_headline output with <b>matched</b> wrappers;
+     style them so the highlight pops without screaming. */
+}
+
+.paletteHitExcerpt :global(b) {
+  font-weight: 700;
+  color: rgb(180, 220, 255);
+  background: rgba(120, 200, 255, 0.08);
+  border-radius: 2px;
+  padding: 0 0.1em;
+}
+
+.paletteSkeleton {
+  padding: 0.7rem 0.85rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.paletteSkeletonTitle,
+.paletteSkeletonExcerpt {
+  display: block;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: paletteShimmer 1.2s infinite;
+}
+
+.paletteSkeletonTitle {
+  height: 14px;
+  width: 60%;
+}
+
+.paletteSkeletonExcerpt {
+  height: 28px;
+  width: 100%;
+}
+
+@keyframes paletteShimmer {
+  from { background-position: 100% 0; }
+  to { background-position: -100% 0; }
+}
+
+.paletteFooter {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  font-size: 0.72rem;
+  color: var(--text-tertiary, rgba(255, 255, 255, 0.45));
+}
+
+.paletteFooter kbd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  font-size: 0.7rem;
+  padding: 0.05rem 0.35rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  margin-right: 0.3rem;
+}
+
+@media (max-width: 640px) {
+  /* Hide the keyboard hint footer on phones — they don't have one. */
+  .paletteFooter {
+    display: none;
+  }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -41,6 +41,12 @@ export { default as CodexPreview, type CodexNote, type CodexResolvedLink } from 
 export { default as CodexEditor } from './CodexEditor';
 export { default as CodexGraph } from './CodexGraph';
 export { default as CodexSearch, type CodexSearchHit } from './CodexSearch';
+export {
+  SearchPalette,
+  SearchPaletteTrigger,
+  openSearchPalette,
+  type SearchPaletteProps,
+} from './SearchPalette';
 export { default as CommandPalette, type PaletteAction } from './CommandPalette';
 export { default as QuickOpen } from './QuickOpen';
 export { default as KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';


### PR DESCRIPTION
Centered modal on desktop / bottom sheet on mobile. Mode picker (Hybrid / Full-text / Substring / Tags) maps to the SearchAdapter contract; recent searches in localStorage; keyboard-first nav; ts_headline excerpts rendered with highlighted spans. Doesn't bind its own hotkey — hosts call `openSearchPalette()` from whatever binding they choose. Closes #21.