### PR TITLE
ux(naming): rename note → document in user-facing strings + drop sidebar search

### DIFF
--- a/src/ui/CodexBrowser.tsx
+++ b/src/ui/CodexBrowser.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import CodexTree, { type CodexTreeNode, noteHref } from './CodexTree';
 import CodexPreview, { type CodexNote } from './CodexPreview';
 import CodexGraph from './CodexGraph';
-import CodexSearch, { type CodexSearchHit } from './CodexSearch';
 import CodexEditor from './CodexEditor';
 import NewNoteDialog, { defaultNewNoteContent } from './NewNoteDialog';
 import RenameDialog from './RenameDialog';
@@ -169,7 +168,6 @@ export default function CodexBrowser({
   const [loadingTree, setLoadingTree] = useState(true);
   const [loadingNote, setLoadingNote] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [searchHits, setSearchHits] = useState<CodexSearchHit[] | null>(null);
   const [editing, setEditing] = useState<boolean>(false);
   const [newNoteOpen, setNewNoteOpen] = useState<boolean>(false);
   const [renameTarget, setRenameTarget] = useState<CodexTreeNode | null>(null);
@@ -256,10 +254,6 @@ export default function CodexBrowser({
       cancelled = true;
     };
   }, [view, selectedPath, startInCreate]);
-
-  const onSearchResults = useCallback((hits: CodexSearchHit[] | null) => {
-    setSearchHits(hits);
-  }, []);
 
   const handleRenamed = useCallback(
     async (newPath: string, rewrittenCount: number) => {
@@ -427,7 +421,7 @@ export default function CodexBrowser({
   }, [selectedPath, refreshTree, router, startInCreate]);
 
   // Helper: walk the tree to find the CodexTreeNode for the currently-
-  // selected path, so palette actions like "Rename current note" have a node
+  // selected path, so palette actions like "Rename current document" have a node
   // to operate on.
   const currentNode = useMemo<CodexTreeNode | null>(() => {
     if (!selectedPath || !tree) return null;
@@ -459,7 +453,7 @@ export default function CodexBrowser({
       },
       {
         id: 'quick-open',
-        label: 'Quick open note…',
+        label: 'Quick open document…',
         category: 'Navigation',
         keywords: ['find', 'search', 'jump'],
         run: () => setQuickOpenOpen(true),
@@ -502,22 +496,22 @@ export default function CodexBrowser({
       list.push(
         {
           id: 'rename-current',
-          label: `Rename current note (${currentNode.name})…`,
-          category: 'Note',
+          label: `Rename current document (${currentNode.name})…`,
+          category: 'Document',
           keywords: ['mv', 'move'],
           run: () => setRenameTarget(currentNode),
         },
         {
           id: 'delete-current',
-          label: `Delete current note (${currentNode.name})…`,
-          category: 'Note',
+          label: `Delete current document (${currentNode.name})…`,
+          category: 'Document',
           keywords: ['rm', 'remove'],
           run: () => setDeleteTarget(currentNode),
         },
         {
           id: 'edit-current',
-          label: `Edit current note (${currentNode.name})`,
-          category: 'Note',
+          label: `Edit current document (${currentNode.name})`,
+          category: 'Document',
           run: () => setEditing(true),
         },
       );
@@ -525,16 +519,16 @@ export default function CodexBrowser({
       if (prefs?.pinnedPaths.includes(currentNode.path)) {
         list.push({
           id: 'unpin-current',
-          label: `Unpin current note (${currentNode.name})`,
-          category: 'Note',
+          label: `Unpin current document (${currentNode.name})`,
+          category: 'Document',
           keywords: ['favorite'],
           run: () => void unpinNote(currentNode.path),
         });
       } else {
         list.push({
           id: 'pin-current',
-          label: `Pin current note (${currentNode.name})`,
-          category: 'Note',
+          label: `Pin current document (${currentNode.name})`,
+          category: 'Document',
           keywords: ['favorite', 'star'],
           run: () => void pinNote(currentNode.path),
         });
@@ -591,9 +585,9 @@ export default function CodexBrowser({
   // Register entries for the Cmd+? help dialog.
   useEffect(() => {
     return registerShortcutHelp([
-      { combo: 'mod+s', label: 'Save current note', category: 'Editor' },
+      { combo: 'mod+s', label: 'Save current document', category: 'Editor' },
       { combo: 'mod+k', label: 'Open command palette', category: 'Navigation' },
-      { combo: 'mod+p', label: 'Quick open note', category: 'Navigation' },
+      { combo: 'mod+p', label: 'Quick open document', category: 'Navigation' },
       { combo: 'mod+shift+f', label: 'Find &amp; replace across vault', category: 'Vault' },
       { combo: 'mod+/', label: 'Show this help', category: 'Help' },
       { combo: 'F2', label: 'Rename focused note', category: 'Tree' },
@@ -743,15 +737,13 @@ export default function CodexBrowser({
           </Link>
         </div>
 
-        <CodexSearch onResults={onSearchResults} />
-
         <button
           type="button"
           className={styles.btnPrimary}
           style={{ width: '100%', marginBottom: '0.25rem' }}
           onClick={() => setNewNoteOpen(true)}
         >
-          + New note
+          + New document
         </button>
         <button
           type="button"
@@ -827,55 +819,29 @@ export default function CodexBrowser({
         />
 
         <h3 className={styles.sidebarHeader}>
-          <span>{searchHits === null ? 'AbydosCodex' : 'Search results'}</span>
-          {searchHits === null && tree?.children && (
-            <span style={{ fontWeight: 400 }}>{countNotes(tree)} notes</span>
-          )}
-          {searchHits !== null && (
-            <span style={{ fontWeight: 400 }}>{searchHits.length} hits</span>
+          <span>AbydosCodex</span>
+          {tree?.children && (
+            <span style={{ fontWeight: 400 }}>{countNotes(tree)} documents</span>
           )}
         </h3>
 
-        {searchHits === null ? (
-          loadingTree ? (
-            <div className={styles.spinnerWrap}>Loading vault…</div>
-          ) : (
-            <CodexTree
-              root={tree}
-              selectedPath={selectedPath}
-              onRename={(node) => setRenameTarget(node)}
-              onDelete={(node) => setDeleteTarget(node)}
-              onCreateFolder={(parent) => setNewFolderState({ parent })}
-              onRenameFolder={(node) => setRenameFolderTarget(node)}
-              onDeleteFolder={(node) => setDeleteFolderTarget(node)}
-              onMove={handleMove}
-              multiSelect={{
-                selected: multiSelected,
-                onToggle: handleMultiSelectToggle,
-              }}
-            />
-          )
-        ) : searchHits.length === 0 ? (
-          <div className={styles.spinnerWrap}>No matches</div>
+        {loadingTree ? (
+          <div className={styles.spinnerWrap}>Loading vault…</div>
         ) : (
-          <ul className={styles.searchResultsList}>
-            {searchHits.map((hit) => (
-              <li key={hit.note.path}>
-                <Link
-                  href={noteHref(hit.note.path)}
-                  className={`${styles.searchResultRow} ${
-                    selectedPath === hit.note.path ? styles.noteRowActive : ''
-                  }`}
-                >
-                  <span>{hit.note.title}</span>
-                  <span className={styles.searchResultMeta}>
-                    {hit.note.folder} · {hit.matchedOn}
-                  </span>
-                  {hit.excerpt && <span className={styles.searchResultExcerpt}>{hit.excerpt}</span>}
-                </Link>
-              </li>
-            ))}
-          </ul>
+          <CodexTree
+            root={tree}
+            selectedPath={selectedPath}
+            onRename={(node) => setRenameTarget(node)}
+            onDelete={(node) => setDeleteTarget(node)}
+            onCreateFolder={(parent) => setNewFolderState({ parent })}
+            onRenameFolder={(node) => setRenameFolderTarget(node)}
+            onDeleteFolder={(node) => setDeleteFolderTarget(node)}
+            onMove={handleMove}
+            multiSelect={{
+              selected: multiSelected,
+              onToggle: handleMultiSelectToggle,
+            }}
+          />
         )}
       </aside>
 
@@ -890,7 +856,7 @@ export default function CodexBrowser({
           />
         )}
         {!error && view === 'note' && loadingNote && (
-          <div className={styles.spinnerWrap}>Loading note…</div>
+          <div className={styles.spinnerWrap}>Loading document…</div>
         )}
         {!error && showEditor && selectedPath && (
           <CodexEditor
@@ -935,7 +901,7 @@ export default function CodexBrowser({
           </>
         )}
         {!error && view === 'note' && !loadingNote && !note && !showCreateMode && selectedPath && (
-          <div className={styles.error}>Note not found: {selectedPath}</div>
+          <div className={styles.error}>Document not found: {selectedPath}</div>
         )}
       </main>
 
@@ -1017,8 +983,8 @@ function Welcome() {
       <p>
         The cross-product knowledge vault. Browse by folder on the left, search by title, tag,
         or body content; switch to <Link href="/admin/codex/graph">Graph</Link> for the link
-        map. Click any note to read; click <strong>Edit</strong> in the note header to update
-        it (changes commit + push back to the vault repo).
+        map. Click any document to read; click <strong>Edit</strong> in the document header to
+        update it (changes commit + push back to the vault repo).
       </p>
       <ul>
         <li><strong>20 - Products</strong> — current state of each product</li>

--- a/src/ui/CodexEditor.tsx
+++ b/src/ui/CodexEditor.tsx
@@ -348,7 +348,7 @@ export default function CodexEditor({
     <div className={styles.editorRoot}>
       <div className={styles.editorHeader}>
         <div>
-          <strong>{baseSha === null ? 'New note' : 'Editing'}</strong>
+          <strong>{baseSha === null ? 'New document' : 'Editing'}</strong>
           <span className={styles.notePath} style={{ marginLeft: '0.5rem' }}>{path}</span>
         </div>
         <div className={styles.editorActions}>
@@ -367,7 +367,7 @@ export default function CodexEditor({
                   .join('/')
               }
               className={styles.btnSecondary}
-              title="Show this note's link graph (across all folders)"
+              title="Show this document's link graph (across all folders)"
             >
               🕸 Linkages
             </a>
@@ -389,7 +389,7 @@ export default function CodexEditor({
 
       {isAutoManaged && (
         <div className={styles.autoBanner}>
-          This note has an auto-managed Activity section that the nightly journal-mining
+          This document has an auto-managed Activity section that the nightly journal-mining
           script regenerates. Edit safe sections (Sessions, Decisions, Notes) only.
         </div>
       )}
@@ -397,7 +397,7 @@ export default function CodexEditor({
       <input
         type="text"
         className={styles.editorCommitMessage}
-        placeholder="Why? (optional — adds a note to this commit)"
+        placeholder="Why? (optional — adds context to this commit)"
         value={userMessage}
         onChange={(e) => setUserMessage(e.target.value)}
         aria-label="Optional commit reason"
@@ -448,7 +448,7 @@ export default function CodexEditor({
           visibleDragbar={false}
         />
         {dragActive && (
-          <div className={styles.editorDropOverlay}>Drop to attach to this note</div>
+          <div className={styles.editorDropOverlay}>Drop to attach to this document</div>
         )}
       </div>
 

--- a/src/ui/CodexGraph.tsx
+++ b/src/ui/CodexGraph.tsx
@@ -678,7 +678,7 @@ export default function CodexGraph({ scope, noteFocus, noteFocusDepth = 2 }: Pro
                           e.stopPropagation();
                           router.push(linkagesUrl(n.id));
                         }}
-                        title="Pivot the linkages view onto this note"
+                        title="Pivot the linkages view onto this document"
                         aria-label="Pivot linkages"
                       >
                         🕸
@@ -724,7 +724,7 @@ export default function CodexGraph({ scope, noteFocus, noteFocusDepth = 2 }: Pro
                           e.stopPropagation();
                           router.push(linkagesUrl(n.id));
                         }}
-                        title="Pivot the linkages view onto this note"
+                        title="Pivot the linkages view onto this document"
                         aria-label="Pivot linkages"
                       >
                         🕸

--- a/src/ui/CodexNotePreviewPane.tsx
+++ b/src/ui/CodexNotePreviewPane.tsx
@@ -100,7 +100,7 @@ export default function CodexNotePreviewPane({
             type="button"
             className={styles.notePreviewPaneActionBtn}
             onClick={() => onOpenLinkages(notePath)}
-            title="Open this note's linkages graph (centered on this note)"
+            title="Open this document's linkages graph (centered on this document)"
           >
             🕸
           </button>
@@ -108,7 +108,7 @@ export default function CodexNotePreviewPane({
             type="button"
             className={styles.notePreviewPaneActionBtn}
             onClick={() => onEdit(notePath)}
-            title="Open this note in editor"
+            title="Open this document in editor"
           >
             ✎
           </button>

--- a/src/ui/CodexTagBrowser.tsx
+++ b/src/ui/CodexTagBrowser.tsx
@@ -126,7 +126,7 @@ export default function CodexTagBrowser() {
   async function handleDelete(tagName: string) {
     if (
       !confirm(
-        `Remove tag #${tagName} from every note that uses it? This is one git commit; auto-managed notes are skipped.`,
+        `Remove tag #${tagName} from every document that uses it? This is one git commit; auto-managed documents are skipped.`,
       )
     )
       return;
@@ -210,17 +210,17 @@ export default function CodexTagBrowser() {
         {!active ? (
           <div className={styles.welcome}>
             <h2>Tag browser</h2>
-            <p>Click a tag on the left to see the notes that use it. From there, rename the tag (rewrites every note&apos;s frontmatter) or delete it (removes from every note). Auto-managed notes are skipped by both operations.</p>
+            <p>Click a tag on the left to see the documents that use it. From there, rename the tag (rewrites every document&apos;s frontmatter) or delete it (removes from every document). Auto-managed documents are skipped by both operations.</p>
             <ul>
               <li>Total tags in vault: <strong>{tags.length}</strong></li>
-              <li>Total tagged notes (sum of counts): <strong>{tags.reduce((acc, t) => acc + t.count, 0)}</strong></li>
+              <li>Total tagged documents (sum of counts): <strong>{tags.reduce((acc, t) => acc + t.count, 0)}</strong></li>
             </ul>
           </div>
         ) : (
           <div>
             <div className={styles.noteHeader}>
               <h2 style={{ margin: 0 }}>#{active.tag}</h2>
-              <span className={styles.tagListCount}>{active.count} note{active.count === 1 ? '' : 's'}</span>
+              <span className={styles.tagListCount}>{active.count} document{active.count === 1 ? '' : 's'}</span>
               <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.5rem' }}>
                 <button
                   type="button"

--- a/src/ui/CodexTree.tsx
+++ b/src/ui/CodexTree.tsx
@@ -483,7 +483,7 @@ function NoteTreeItem({
       <a
         href={linkagesHref}
         className={styles.noteRowLinkagesIcon}
-        title="Show this note's link graph (across all folders)"
+        title="Show this document's link graph (across all folders)"
         aria-label="Show linkages"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/ui/DeleteConfirmDialog.tsx
+++ b/src/ui/DeleteConfirmDialog.tsx
@@ -156,7 +156,7 @@ export default function DeleteConfirmDialog({ open, path, onClose, onDeleted }: 
         role="dialog"
         aria-modal="true"
       >
-        <h3 style={{ marginTop: 0 }}>Delete note</h3>
+        <h3 style={{ marginTop: 0 }}>Delete document</h3>
         <p style={{ marginTop: 0, fontSize: '0.85rem' }}>
           You are about to delete <strong>{path}</strong>. This action cannot be undone
           (the file is removed from the vault and committed to git history).

--- a/src/ui/NewNoteDialog.tsx
+++ b/src/ui/NewNoteDialog.tsx
@@ -81,7 +81,7 @@ export default function NewNoteDialog({ open, onClose }: Props) {
               type="text"
               value={filename}
               onChange={(e) => setFilename(e.target.value)}
-              placeholder="My new note"
+              placeholder="My new document"
               autoFocus
             />
           </label>

--- a/src/ui/QuickOpen.tsx
+++ b/src/ui/QuickOpen.tsx
@@ -146,7 +146,7 @@ export default function QuickOpen({ open, onClose }: Props) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Search notes by title…"
+          placeholder="Search documents by title…"
           spellCheck={false}
           data-allow-text="true"
         />

--- a/src/ui/RenameDialog.tsx
+++ b/src/ui/RenameDialog.tsx
@@ -130,7 +130,7 @@ export default function RenameDialog({ open, oldPath, onClose, onRenamed }: Prop
         role="dialog"
         aria-modal="true"
       >
-        <h3 style={{ marginTop: 0 }}>Rename note</h3>
+        <h3 style={{ marginTop: 0 }}>Rename document</h3>
         <p style={{ marginTop: 0, fontSize: '0.85rem', opacity: 0.85 }}>
           Inbound wikilinks across the vault will be updated automatically. The
           rename and every rewrite are committed in a single git commit.


### PR DESCRIPTION
Document → vault entity, note → user-added annotation (per chriscase/AbydosTemple naming clarification). Internal symbol names stay (vaultNote / NoteMeta / CodexNoteType / view='note') — high-risk for zero gain. Sidebar CodexSearch input removed since the Cmd-K palette (#34) supersedes it.