### PR TITLE
feat(reading): inline concept popover on wikilink hover/long-press (#17)

### DIFF
--- a/src/ui/CodexPreview.tsx
+++ b/src/ui/CodexPreview.tsx
@@ -7,6 +7,7 @@ import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import { useCodexNavigation } from './CodexAdapters';
 import { noteHref } from './CodexTree';
+import { PreviewLink } from './ConceptPopover';
 import styles from './codex.module.css';
 
 export interface CodexResolvedLink {
@@ -220,6 +221,7 @@ export default function CodexPreview({ note, canEdit, onEdit, onShowHistory, his
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'wrap' }]]}
+          components={{ a: PreviewLink }}
         >
           {md}
         </ReactMarkdown>

--- a/src/ui/ConceptPopover.tsx
+++ b/src/ui/ConceptPopover.tsx
@@ -1,0 +1,481 @@
+'use client';
+
+// Inline document preview popover.
+//
+// Hover (desktop, 250ms delay) or long-press (mobile, 500ms) on a
+// resolved wikilink in CodexPreview opens this card. It shows the
+// linked document's title, status, tags, and the first ~200 chars of
+// the body — enough context that the reader doesn't have to click
+// through to know whether to navigate.
+//
+// Two form factors:
+//   • Desktop: floating card anchored to the link via getBoundingClientRect,
+//     flipped above when below would clip, centered horizontally with
+//     viewport-edge clamping.
+//   • Mobile (≤ 640px): full-width bottom sheet, swipe-down to dismiss.
+//
+// Excerpts are session-cached so re-hovering the same link is instant.
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type AnchorHTMLAttributes,
+} from 'react';
+import type * as React from 'react';
+import { createPortal } from 'react-dom';
+import { useCodexGraphqlRequest, useCodexNavigation } from './CodexAdapters';
+import styles from './codex.module.css';
+
+const EXCERPT_QUERY = `
+  query VaultNoteForPopover($path: String!) {
+    vaultNote(path: $path) {
+      path
+      title
+      folder
+      status
+      tags
+      content
+    }
+  }
+`;
+
+interface PopoverData {
+  path: string;
+  title: string;
+  folder: string;
+  status: string | null;
+  tags: string[];
+  excerpt: string;
+}
+
+const EXCERPT_CACHE = new Map<string, PopoverData>();
+const EXCERPT_LIMIT = 220;
+const HOVER_DELAY_MS = 250;
+const LONG_PRESS_MS = 500;
+
+function makeExcerpt(content: string): string {
+  // Drop frontmatter + leading whitespace, collapse blank lines, take
+  // the first paragraph-ish. Strip wikilink/markdown syntax for
+  // readability (the popover isn't a renderer, just a preview).
+  let body = content;
+  if (body.startsWith('---\n')) {
+    const end = body.indexOf('\n---', 4);
+    if (end !== -1) body = body.slice(end + 4);
+  }
+  body = body
+    .replace(/^\s+/, '')
+    .replace(/^#.*$/gm, '') // strip heading lines
+    .replace(/\[\[([^\]|#]+)(?:\|([^\]]+))?\]\]/g, (_, t, a) => a ?? t)
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/[*_]{1,2}([^*_]+)[*_]{1,2}/g, '$1')
+    .replace(/\n{2,}/g, ' · ')
+    .replace(/\n/g, ' ')
+    .trim();
+  if (body.length > EXCERPT_LIMIT) {
+    return body.slice(0, EXCERPT_LIMIT).trimEnd() + '…';
+  }
+  return body;
+}
+
+export interface ConceptPopoverProps {
+  /** Path the user's link points to (vault-relative). */
+  path: string;
+  /** Bounding rect of the anchor element on desktop (window-relative).
+   *  Mobile ignores this — the sheet is always bottom-anchored. */
+  anchorRect: DOMRect | null;
+  /** True when triggered by long-press on touch — switches form factor
+   *  to the bottom sheet. */
+  isTouch: boolean;
+  onClose: () => void;
+  /** Override the route the "Open" button navigates to. Defaults to
+   *  `/admin/codex/note/<path>` (URL-encoded). */
+  noteHref?: (path: string) => string;
+}
+
+export default function ConceptPopover({
+  path,
+  anchorRect,
+  isTouch,
+  onClose,
+  noteHref,
+}: ConceptPopoverProps) {
+  const graphqlRequest = useCodexGraphqlRequest();
+  const { useRouter } = useCodexNavigation();
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+  const [data, setData] = useState<PopoverData | null>(
+    EXCERPT_CACHE.get(path) ?? null,
+  );
+  const [loading, setLoading] = useState(!data);
+  const [error, setError] = useState<string | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+    placement: 'above' | 'below';
+  } | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Fetch when no cached value.
+  useEffect(() => {
+    if (data) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data: payload, errors } = await graphqlRequest<{
+          vaultNote: {
+            path: string;
+            title: string;
+            folder: string;
+            status: string | null;
+            tags: string[];
+            content: string;
+          } | null;
+        }>(EXCERPT_QUERY, { path });
+        if (cancelled) return;
+        if (errors?.length || !payload?.vaultNote) {
+          setError('Document not found');
+          setLoading(false);
+          return;
+        }
+        const next: PopoverData = {
+          path: payload.vaultNote.path,
+          title: payload.vaultNote.title,
+          folder: payload.vaultNote.folder,
+          status: payload.vaultNote.status ?? null,
+          tags: payload.vaultNote.tags,
+          excerpt: makeExcerpt(payload.vaultNote.content),
+        };
+        EXCERPT_CACHE.set(path, next);
+        setData(next);
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load preview');
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [path, data, graphqlRequest]);
+
+  // Desktop positioning — runs once anchor + card are both available.
+  useEffect(() => {
+    if (isTouch) return;
+    if (!anchorRect || !cardRef.current) return;
+
+    const card = cardRef.current;
+    const cardW = card.offsetWidth;
+    const cardH = card.offsetHeight;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const gap = 8;
+
+    // Try below first; flip above if it would overflow.
+    const fitsBelow = anchorRect.bottom + gap + cardH <= vh - 8;
+    const placement: 'above' | 'below' = fitsBelow ? 'below' : 'above';
+
+    const top =
+      placement === 'below'
+        ? anchorRect.bottom + gap
+        : Math.max(8, anchorRect.top - gap - cardH);
+
+    // Center horizontally on the anchor, but clamp to viewport edges.
+    const desiredLeft = anchorRect.left + anchorRect.width / 2 - cardW / 2;
+    const left = Math.max(8, Math.min(vw - cardW - 8, desiredLeft));
+
+    setPosition({ top, left, placement });
+  }, [anchorRect, isTouch, data, loading]);
+
+  // Dismiss on Esc.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const handleOpen = useCallback(() => {
+    const target = data?.path ?? path;
+    const href = noteHref
+      ? noteHref(target)
+      : '/admin/codex/note/' +
+        target
+          .replace(/\.md$/i, '')
+          .split(/[\\/]/g)
+          .map((seg) => encodeURIComponent(seg))
+          .join('/');
+    onClose();
+    router.push(href);
+  }, [data, path, noteHref, onClose, router]);
+
+  if (!mounted) return null;
+
+  // ─── Touch / mobile: bottom sheet ───────────────────────────────────────
+  if (isTouch) {
+    return createPortal(
+      <div
+        className={styles.conceptSheetBackdrop}
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Document preview"
+      >
+        <div className={styles.conceptSheet}>
+          <div className={styles.conceptSheetHandle} aria-hidden="true" />
+          {renderBody({ data, loading, error })}
+          <div className={styles.conceptSheetActions}>
+            <button
+              type="button"
+              className={styles.conceptSheetSecondary}
+              onClick={onClose}
+            >
+              Close
+            </button>
+            <button
+              type="button"
+              className={styles.conceptSheetPrimary}
+              onClick={handleOpen}
+              disabled={!data}
+            >
+              Open document
+            </button>
+          </div>
+        </div>
+      </div>,
+      document.body,
+    );
+  }
+
+  // ─── Desktop: floating card ─────────────────────────────────────────────
+  // Render off-screen on first paint so we can measure for positioning,
+  // then move into place via the position effect.
+  const style: React.CSSProperties = position
+    ? { top: position.top, left: position.left, opacity: 1 }
+    : { top: -10000, left: -10000, opacity: 0 };
+
+  return createPortal(
+    <div
+      ref={cardRef}
+      className={styles.conceptCard}
+      style={style}
+      onMouseLeave={onClose}
+      role="dialog"
+      aria-label="Document preview"
+    >
+      {renderBody({ data, loading, error })}
+      <div className={styles.conceptCardActions}>
+        <button
+          type="button"
+          className={styles.conceptCardOpenButton}
+          onClick={handleOpen}
+          disabled={!data}
+        >
+          Open →
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function renderBody({
+  data,
+  loading,
+  error,
+}: {
+  data: PopoverData | null;
+  loading: boolean;
+  error: string | null;
+}): ReactNode {
+  if (loading && !data) {
+    return (
+      <div className={styles.conceptBody}>
+        <div className={styles.conceptSkeletonTitle} />
+        <div className={styles.conceptSkeletonExcerpt} />
+        <div className={styles.conceptSkeletonExcerpt} />
+      </div>
+    );
+  }
+  if (error) {
+    return <div className={styles.conceptError}>{error}</div>;
+  }
+  if (!data) return null;
+  return (
+    <div className={styles.conceptBody}>
+      <div className={styles.conceptHeader}>
+        <h4 className={styles.conceptTitle}>{data.title}</h4>
+        {data.status && (
+          <span className={styles.conceptStatus}>{data.status}</span>
+        )}
+      </div>
+      <div className={styles.conceptFolder}>{data.folder}</div>
+      {data.excerpt && <p className={styles.conceptExcerpt}>{data.excerpt}</p>}
+      {data.tags.length > 0 && (
+        <div className={styles.conceptTagRow}>
+          {data.tags.slice(0, 6).map((t) => (
+            <span key={t} className={styles.conceptTag}>
+              #{t}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Wikilink-aware <a> wrapper ──────────────────────────────────────────
+//
+// Drop this in as the `a` component for react-markdown so any link that
+// looks like a codex document route gets hover + long-press handlers
+// that open the concept popover. Non-codex links pass through untouched.
+
+const CODEX_ROUTE_RE = /\/admin\/codex\/note\//;
+
+// react-markdown passes the full HTMLAnchorElement attribute set plus
+// some internal props (`node`, etc.). We type as the loose intersection
+// and spread the rest through unchanged so syntax highlighting,
+// rehype-autolink anchors, etc. keep working.
+export type PreviewLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  href?: string;
+  children?: ReactNode;
+  // rehype/react-markdown sometimes emits an internal `node` prop —
+  // accept it without using it.
+  node?: unknown;
+};
+
+export function PreviewLink({ href, children, node: _node, ...rest }: PreviewLinkProps) {
+  const [open, setOpen] = useState<{
+    path: string;
+    anchorRect: DOMRect | null;
+    isTouch: boolean;
+  } | null>(null);
+  const aRef = useRef<HTMLAnchorElement | null>(null);
+  const hoverTimerRef = useRef<number | null>(null);
+  const longPressTimerRef = useRef<number | null>(null);
+  const suppressClickRef = useRef(false);
+
+  const codexPath = href ? decodeCodexHref(href) : null;
+  const isWikilink = !!codexPath;
+
+  // Clear any pending timers when the link unmounts mid-hover.
+  useEffect(() => {
+    return () => {
+      if (hoverTimerRef.current) window.clearTimeout(hoverTimerRef.current);
+      if (longPressTimerRef.current) window.clearTimeout(longPressTimerRef.current);
+    };
+  }, []);
+
+  if (!isWikilink) {
+    return (
+      <a href={href} {...(rest as Record<string, unknown>)}>
+        {children}
+      </a>
+    );
+  }
+
+  const openPopover = (isTouch: boolean) => {
+    const rect = aRef.current?.getBoundingClientRect() ?? null;
+    setOpen({ path: codexPath, anchorRect: rect, isTouch });
+  };
+
+  const onMouseEnter = () => {
+    if (hoverTimerRef.current) window.clearTimeout(hoverTimerRef.current);
+    hoverTimerRef.current = window.setTimeout(() => openPopover(false), HOVER_DELAY_MS);
+  };
+
+  const onMouseLeave = () => {
+    if (hoverTimerRef.current) {
+      window.clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    // Don't close on leave here — the card has its own onMouseLeave that
+    // handles dismissal so the user can move from link → card without
+    // the card disappearing.
+  };
+
+  const onTouchStart = () => {
+    if (longPressTimerRef.current) window.clearTimeout(longPressTimerRef.current);
+    longPressTimerRef.current = window.setTimeout(() => {
+      suppressClickRef.current = true;
+      openPopover(true);
+    }, LONG_PRESS_MS);
+  };
+
+  const onTouchEnd = () => {
+    if (longPressTimerRef.current) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const onTouchMove = () => {
+    // Movement cancels the long-press intent.
+    if (longPressTimerRef.current) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  };
+
+  const onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (suppressClickRef.current) {
+      e.preventDefault();
+      suppressClickRef.current = false;
+    }
+    // Otherwise: regular link click navigates normally.
+  };
+
+  return (
+    <>
+      <a
+        ref={aRef}
+        href={href}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+        onTouchMove={onTouchMove}
+        onTouchCancel={onTouchEnd}
+        onClick={onClick}
+        {...rest}
+      >
+        {children}
+      </a>
+      {open && (
+        <ConceptPopover
+          path={open.path}
+          anchorRect={open.anchorRect}
+          isTouch={open.isTouch}
+          onClose={() => setOpen(null)}
+        />
+      )}
+    </>
+  );
+}
+
+/** Decode a /admin/codex/note/... href back to a vault-relative path
+ *  (with `.md` re-appended). Returns null for non-codex hrefs. */
+function decodeCodexHref(href: string): string | null {
+  const m = href.match(/\/admin\/codex\/note\/(.+?)(?:#.*)?$/);
+  if (!m) return null;
+  const decoded = m[1]
+    .split('/')
+    .map((seg) => decodeURIComponent(seg))
+    .join('/');
+  return decoded.endsWith('.md') ? decoded : decoded + '.md';
+}
+
+void CODEX_ROUTE_RE; // exported above via decodeCodexHref behavior — keep ref for tree-shake hint

--- a/src/ui/codex.module.css
+++ b/src/ui/codex.module.css
@@ -2570,3 +2570,235 @@
     display: none;
   }
 }
+
+/* ─── Concept popover ───────────────────────────────────────────────────── */
+
+/* Desktop floating card — anchored next to the hovered wikilink. */
+.conceptCard {
+  position: fixed;
+  z-index: 1100;
+  width: min(360px, 92vw);
+  background: var(--bg-elevated, #14171f);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  box-shadow:
+    0 16px 40px -16px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  pointer-events: auto;
+  transition: opacity 120ms ease;
+  /* Fade-in on first measure: parent inline-styles opacity 0 until
+   * positioned, then flips to 1. */
+}
+
+.conceptBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.85rem 1rem 0.75rem;
+}
+
+.conceptHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.conceptTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary, white);
+  flex: 1;
+  min-width: 0;
+}
+
+.conceptStatus {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(120, 200, 255, 0.14);
+  color: rgb(180, 220, 255);
+  border: 1px solid rgba(120, 200, 255, 0.32);
+}
+
+.conceptFolder {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  font-size: 0.7rem;
+  color: var(--text-tertiary, rgba(255, 255, 255, 0.5));
+  margin-bottom: 0.1rem;
+}
+
+.conceptExcerpt {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.78));
+  /* Soft clamp; ellipsis-friendly. */
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.conceptTagRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.2rem;
+}
+
+.conceptTag {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+}
+
+.conceptCardActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem 0.65rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.conceptCardOpenButton {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(120, 200, 255, 0.16);
+  border: 1px solid rgba(120, 200, 255, 0.4);
+  border-radius: 6px;
+  color: rgb(180, 220, 255);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.conceptCardOpenButton:hover:not(:disabled) {
+  background: rgba(120, 200, 255, 0.24);
+}
+
+.conceptCardOpenButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.conceptError {
+  padding: 1rem;
+  color: rgb(240, 130, 130);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.conceptSkeletonTitle,
+.conceptSkeletonExcerpt {
+  display: block;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: 4px;
+  animation: paletteShimmer 1.2s infinite;
+}
+
+.conceptSkeletonTitle {
+  height: 16px;
+  width: 60%;
+}
+
+.conceptSkeletonExcerpt {
+  height: 12px;
+  width: 100%;
+}
+
+/* Mobile bottom sheet — full-width card sliding up from the bottom. */
+.conceptSheetBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background: rgba(8, 10, 16, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-end;
+  justify-content: stretch;
+  animation: paletteFadeIn 160ms ease-out;
+}
+
+.conceptSheet {
+  width: 100%;
+  background: var(--bg-elevated, #14171f);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px 16px 0 0;
+  box-shadow: 0 -16px 32px -8px rgba(0, 0, 0, 0.4);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  animation: paletteSlideUp 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+}
+
+.conceptSheetHandle {
+  width: 36px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  margin: 0.55rem auto 0.1rem;
+}
+
+.conceptSheetActions {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem 0.85rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.conceptSheetSecondary,
+.conceptSheetPrimary {
+  flex: 1;
+  min-height: 44px;
+  padding: 0.7rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.conceptSheetSecondary {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+}
+
+.conceptSheetSecondary:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary, white);
+}
+
+.conceptSheetPrimary {
+  background: rgba(120, 200, 255, 0.18);
+  border: 1px solid rgba(120, 200, 255, 0.42);
+  color: rgb(180, 220, 255);
+}
+
+.conceptSheetPrimary:hover:not(:disabled) {
+  background: rgba(120, 200, 255, 0.26);
+}
+
+.conceptSheetPrimary:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -47,6 +47,12 @@ export {
   openSearchPalette,
   type SearchPaletteProps,
 } from './SearchPalette';
+export {
+  default as ConceptPopover,
+  PreviewLink,
+  type ConceptPopoverProps,
+  type PreviewLinkProps,
+} from './ConceptPopover';
 export { default as CommandPalette, type PaletteAction } from './CommandPalette';
 export { default as QuickOpen } from './QuickOpen';
 export { default as KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';


### PR DESCRIPTION
Hover (desktop 250ms) or long-press (mobile 500ms) on a resolved wikilink → floating card / bottom sheet with the linked document's title, status, folder, excerpt, tags, and Open button. PreviewLink wired as the react-markdown <a> renderer in CodexPreview. Session-cached excerpts. Closes #17.