### PR TITLE
feat(reading): two-pane reading mode with references rail (#18)

### DIFF
--- a/src/ui/CodexPreview.tsx
+++ b/src/ui/CodexPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSlug from 'rehype-slug';
@@ -167,12 +167,61 @@ function statusClass(status: string | null | undefined): string | null {
   }
 }
 
+const READING_MODE_KEY = 'ostracon-reading-mode';
+
+/** Resolved outbound link unique by resolvedPath. Embeds (images, PDFs)
+ *  are filtered out — the rail is for cross-document references. */
+function uniqueResolvedReferences(
+  links: CodexResolvedLink[],
+): Array<{ path: string; title: string; folder: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ path: string; title: string; folder: string }> = [];
+  for (const link of links) {
+    if (link.isEmbed || !link.resolvedPath) continue;
+    if (seen.has(link.resolvedPath)) continue;
+    seen.add(link.resolvedPath);
+    const segments = link.resolvedPath.split(/[\\/]/g);
+    const fileName = segments.pop() ?? link.resolvedPath;
+    const title = fileName.replace(/\.md$/i, '');
+    const folder = segments.length > 0 ? segments[0] : '';
+    out.push({ path: link.resolvedPath, title, folder });
+  }
+  return out;
+}
+
 export default function CodexPreview({ note, canEdit, onEdit, onShowHistory, historyOpen }: Props) {
   const { Link } = useCodexNavigation();
   const md = useMemo(() => {
     const stripped = stripFrontmatter(note.content);
     return rewriteWikilinks(stripped, note.outboundLinks);
   }, [note.content, note.outboundLinks]);
+
+  const references = useMemo(
+    () => uniqueResolvedReferences(note.outboundLinks),
+    [note.outboundLinks],
+  );
+
+  // Reading-mode toggle persists per-browser. Default is OFF — the
+  // rail can crowd narrow viewports, and users opt in explicitly.
+  const [readingMode, setReadingMode] = useState<boolean>(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(READING_MODE_KEY);
+      if (stored === '1') setReadingMode(true);
+    } catch {
+      /* quota / private-mode — ignore */
+    }
+  }, []);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(READING_MODE_KEY, readingMode ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
+  }, [readingMode]);
+  const showRail = readingMode && references.length > 0;
 
   // One delegated set of hover / long-press handlers for ALL wikilinks
   // in the rendered markdown — instead of N PreviewLink components, one
@@ -194,6 +243,21 @@ export default function CodexPreview({ note, canEdit, onEdit, onShowHistory, his
         <h2 style={{ margin: 0 }}>{note.title}</h2>
         {sClass && <span className={`${styles.statusBadge} ${sClass}`}>{note.status}</span>}
         <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.5rem' }}>
+          {references.length > 0 && (
+            <button
+              type="button"
+              className={`${styles.btnSecondary}${readingMode ? ' ' + styles.btnSecondaryActive : ''}`}
+              onClick={() => setReadingMode((v) => !v)}
+              aria-pressed={readingMode ? 'true' : 'false'}
+              title={
+                readingMode
+                  ? 'Hide the references rail'
+                  : `Show ${references.length} reference${references.length === 1 ? '' : 's'} alongside the document`
+              }
+            >
+              {readingMode ? 'Hide references' : `References · ${references.length}`}
+            </button>
+          )}
           {onShowHistory && (
             <button
               type="button"
@@ -228,31 +292,65 @@ export default function CodexPreview({ note, canEdit, onEdit, onShowHistory, his
         </div>
       )}
 
-      <div className={styles.markdown}>
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'wrap' }]]}
-        >
-          {md}
-        </ReactMarkdown>
+      <div
+        className={
+          showRail ? styles.readingModeLayout : styles.readingModeLayoutSingle
+        }
+      >
+        <div className={styles.readingModeBody}>
+          <div className={styles.markdown}>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'wrap' }]]}
+            >
+              {md}
+            </ReactMarkdown>
+          </div>
+
+          {note.inboundLinks.length > 0 && (
+            <div className={styles.inboundLinks}>
+              <h3>Linked from</h3>
+              <ul>
+                {note.inboundLinks.map((link) => (
+                  <li key={link.path}>
+                    <Link href={noteHref(link.path)}>{link.title}</Link>
+                    <span className={styles.notePath} style={{ marginLeft: '0.5rem' }}>
+                      {link.folder}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        {showRail && (
+          <aside className={styles.referencesRail} aria-label="References in this document">
+            <div className={styles.referencesRailHeader}>
+              <h3 className={styles.referencesRailTitle}>References</h3>
+              <span className={styles.referencesRailCount}>{references.length}</span>
+            </div>
+            <p className={styles.referencesRailHint}>
+              Hover any card for a preview without leaving the page.
+            </p>
+            <ul className={styles.referencesList}>
+              {references.map((r) => (
+                <li key={r.path}>
+                  <Link href={noteHref(r.path)} className={styles.referencesCard}>
+                    <span className={styles.referencesCardTitle}>{r.title}</span>
+                    {r.folder && (
+                      <span className={styles.referencesCardFolder}>
+                        {r.folder.replace(/^\d+\s*-\s*/, '')}
+                      </span>
+                    )}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
       </div>
       {popover}
-
-      {note.inboundLinks.length > 0 && (
-        <div className={styles.inboundLinks}>
-          <h3>Linked from</h3>
-          <ul>
-            {note.inboundLinks.map((link) => (
-              <li key={link.path}>
-                <Link href={noteHref(link.path)}>{link.title}</Link>
-                <span className={styles.notePath} style={{ marginLeft: '0.5rem' }}>
-                  {link.folder}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/ui/codex.module.css
+++ b/src/ui/codex.module.css
@@ -2831,3 +2831,132 @@
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* ─── Reading mode (two-pane document + references rail) ────────────── */
+
+/* Single-column fallback when the rail is off — keeps the body
+   inheriting the natural .markdown / .inboundLinks layout, no flex. */
+.readingModeLayoutSingle {
+  display: block;
+}
+
+/* Two-column layout active. On desktop the rail sits to the right of
+   the body; on phones / narrow tablets it stacks below the body. */
+.readingModeLayout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) min(360px, 36%);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.readingModeBody {
+  min-width: 0;
+}
+
+@media (max-width: 960px) {
+  .readingModeLayout {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+  }
+}
+
+/* Reference rail */
+.referencesRail {
+  position: sticky;
+  top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.85rem 0.9rem 1rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+@media (max-width: 960px) {
+  .referencesRail {
+    position: static;
+    max-height: none;
+  }
+}
+
+.referencesRailHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.referencesRailTitle {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.65));
+}
+
+.referencesRailCount {
+  font-size: 0.7rem;
+  padding: 0.05rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(120, 200, 255, 0.14);
+  color: rgb(180, 220, 255);
+  border: 1px solid rgba(120, 200, 255, 0.32);
+  font-weight: 600;
+}
+
+.referencesRailHint {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--text-tertiary, rgba(255, 255, 255, 0.45));
+  line-height: 1.4;
+}
+
+.referencesList {
+  list-style: none;
+  margin: 0.2rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.referencesCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.015);
+  color: var(--text-primary, white);
+  text-decoration: none;
+  transition: background 100ms ease, border-color 100ms ease, transform 100ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.referencesCard:hover,
+.referencesCard:focus-visible {
+  background: rgba(120, 200, 255, 0.06);
+  border-color: rgba(120, 200, 255, 0.3);
+  outline: none;
+}
+
+.referencesCard:active {
+  transform: translateY(1px);
+}
+
+.referencesCardTitle {
+  font-weight: 600;
+  font-size: 0.88rem;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+.referencesCardFolder {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  font-size: 0.68rem;
+  color: var(--text-tertiary, rgba(255, 255, 255, 0.45));
+}


### PR DESCRIPTION
Toggle in the document header surfaces a sticky rail of every unique resolved outbound reference — alongside the body on desktop, stacked below on narrow viewports. Pairs with the concept popover from #17: cards have the same hover/long-press preview as inline wikilinks. State persisted in localStorage. Closes #18.