### PR TITLE
perf(codex-browser): memoize CodexTree + CodexPreview + handlers

### DIFF
--- a/src/ui/CodexBrowser.tsx
+++ b/src/ui/CodexBrowser.tsx
@@ -711,6 +711,46 @@ export default function CodexBrowser({
 
   const titleFromPath = (rel: string) => rel.split('/').pop()?.replace(/\.md$/, '') ?? 'New note';
 
+  // ─── Stable handlers for CodexTree ────────────────────────────────────
+  // The tree is one of the most expensive children to re-render at corpus
+  // scale; React.memo on the export below makes that conditional on prop
+  // equality, but that only works if every prop is stable. These
+  // useCallback wrappers replace inline arrow functions that would have
+  // defeated the memoization otherwise.
+  const onTreeRename = useCallback(
+    (node: CodexTreeNode) => setRenameTarget(node),
+    [],
+  );
+  const onTreeDelete = useCallback(
+    (node: CodexTreeNode) => setDeleteTarget(node),
+    [],
+  );
+  const onTreeCreateFolder = useCallback(
+    (parent: CodexTreeNode | null) => setNewFolderState({ parent }),
+    [],
+  );
+  const onTreeRenameFolder = useCallback(
+    (node: CodexTreeNode) => setRenameFolderTarget(node),
+    [],
+  );
+  const onTreeDeleteFolder = useCallback(
+    (node: CodexTreeNode) => setDeleteFolderTarget(node),
+    [],
+  );
+  // Memoized container — without this, a new `{ selected, onToggle }` object
+  // every render would defeat CodexTree's prop-equality check.
+  const treeMultiSelect = useMemo(
+    () => ({ selected: multiSelected, onToggle: handleMultiSelectToggle }),
+    [multiSelected, handleMultiSelectToggle],
+  );
+
+  // Same pattern for the preview's inline handlers.
+  const onPreviewEdit = useCallback(() => setEditing(true), []);
+  const onPreviewShowHistory = useCallback(
+    () => setHistoryOpen((v) => !v),
+    [],
+  );
+
   return (
     // data-view drives the mobile sidebar visibility rule in codex.module.css
     // — on narrow screens, the sidebar gets `display: none` when view='note'
@@ -831,16 +871,13 @@ export default function CodexBrowser({
           <CodexTree
             root={tree}
             selectedPath={selectedPath}
-            onRename={(node) => setRenameTarget(node)}
-            onDelete={(node) => setDeleteTarget(node)}
-            onCreateFolder={(parent) => setNewFolderState({ parent })}
-            onRenameFolder={(node) => setRenameFolderTarget(node)}
-            onDeleteFolder={(node) => setDeleteFolderTarget(node)}
+            onRename={onTreeRename}
+            onDelete={onTreeDelete}
+            onCreateFolder={onTreeCreateFolder}
+            onRenameFolder={onTreeRenameFolder}
+            onDeleteFolder={onTreeDeleteFolder}
             onMove={handleMove}
-            multiSelect={{
-              selected: multiSelected,
-              onToggle: handleMultiSelectToggle,
-            }}
+            multiSelect={treeMultiSelect}
           />
         )}
       </aside>
@@ -876,8 +913,8 @@ export default function CodexBrowser({
             <CodexPreview
               note={note}
               canEdit
-              onEdit={() => setEditing(true)}
-              onShowHistory={() => setHistoryOpen((v) => !v)}
+              onEdit={onPreviewEdit}
+              onShowHistory={onPreviewShowHistory}
               historyOpen={historyOpen}
             />
             {historyOpen && (

--- a/src/ui/CodexPreview.tsx
+++ b/src/ui/CodexPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSlug from 'rehype-slug';
@@ -189,7 +189,11 @@ function uniqueResolvedReferences(
   return out;
 }
 
-export default function CodexPreview({ note, canEdit, onEdit, onShowHistory, historyOpen }: Props) {
+// Memoized so unrelated parent re-renders (sidebar dialog opens,
+// search-palette open/close, etc.) skip the full re-render of the
+// rendered markdown body. Caller must keep handler props stable —
+// see CodexBrowser's onPreviewEdit / onPreviewShowHistory useCallbacks.
+function CodexPreviewInner({ note, canEdit, onEdit, onShowHistory, historyOpen }: Props) {
   const { Link } = useCodexNavigation();
   const md = useMemo(() => {
     const stripped = stripFrontmatter(note.content);
@@ -354,3 +358,6 @@ export default function CodexPreview({ note, canEdit, onEdit, onShowHistory, his
     </div>
   );
 }
+
+const CodexPreview = memo(CodexPreviewInner);
+export default CodexPreview;

--- a/src/ui/CodexTree.tsx
+++ b/src/ui/CodexTree.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { memo, useState, useMemo, useCallback } from 'react';
 import { useCodexNavigation } from './CodexAdapters';
 import styles from './codex.module.css';
 
@@ -70,7 +70,12 @@ function noteHref(relPath: string): string {
     .join('/');
 }
 
-export default function CodexTree({
+// Memoized so a parent re-render that doesn't change tree props
+// (e.g. a sidebar dialog opens elsewhere in CodexBrowser) skips the
+// tree re-render entirely. Caller must keep handlers + multiSelect
+// referentially stable for this to actually help — see CodexBrowser's
+// useCallback / useMemo discipline at the call site.
+function CodexTreeInner({
   root,
   selectedPath,
   onRename,
@@ -102,6 +107,9 @@ export default function CodexTree({
     </ul>
   );
 }
+
+const CodexTree = memo(CodexTreeInner);
+export default CodexTree;
 
 function TreeItem({
   node,


### PR DESCRIPTION
Three targeted changes: wrap inline tree/preview handlers in useCallback, memoize the multiSelect object, wrap CodexTree + CodexPreview exports in React.memo. Pure perf — no behavior change. 237/237 vitest pass. Full Playwright E2E suite (HoR-side) will run against the deployed change to validate no user-visible regression.